### PR TITLE
Sanitize path names

### DIFF
--- a/documentation/variables.js
+++ b/documentation/variables.js
@@ -6,9 +6,24 @@ const verboseName = packageConfig.verboseName
 
 const rootDir = path.resolve(__dirname, '..')
 
-const srcDir = path.resolve(rootDir, 'src')
-const docsDir = path.resolve(rootDir, 'docs')
-const storybookDir = path.resolve(docsDir, 'storybook')
+let srcDir = path.resolve(rootDir, 'src')
+let docsDir = path.resolve(rootDir, 'docs')
+let storybookDir = path.resolve(docsDir, 'storybook')
+
+const sanitizePath = (path) => {
+  if(process.platform != 'win32'){
+    let tokens = path.split("/")
+    tokens = tokens.map(token => token.replace(/(\s+)/g, '\\$1'))
+    return tokens.join("/")
+  }
+  else{
+    return path
+  }
+}
+
+srcDir = sanitizePath(srcDir)
+docsDir = sanitizePath(docsDir)
+storybookDir = sanitizePath(storybookDir)
 
 module.exports = {
   verboseName,


### PR DESCRIPTION
**Fixes**
<!-- If PR only partly solves the issue, replace 'Fixes' below with 'Partially addresses' -->
Partially addresses #47 by @nilshah98 

**Description**
<!-- A clear and concise description of what the pull request does. -->
- Sanitized path name for different OS, except Windows
- Sanitized by adding `\` to escape white space, so `Creative Commons` becomes `Creative\ Commons`

**Type of PR** 
This PR is a [feature|hotfix|refactor].
- Hotfix

**Technicalities**
<!-- Notable technical details about the implementation. -->
- Added a function to sanitize paths, in `documentation/variables.js`
- Split by `/` and then sanitized each using regex - `path.replace((/(\s+)/g,'\\$1)'` and then joined again using `/`
- For windows OS, tried wrapping the path with single inverted commas and even double inverted commas as -`'C:\path\to\folder'`, but couldn't fix it.

**Tests**
<!-- Steps for the reviewer to verify that this PR fixes the problem. -->

**Screenshots**
<!-- If applicable, add screenshots to show the problem and the solution. -->
**Windows Error**
![image](https://user-images.githubusercontent.com/22821480/72964160-1fe00d80-3ddf-11ea-9a52-a589cdc16477.png)

**Ubuntu Works**
![image](https://user-images.githubusercontent.com/22821480/72964771-c11b9380-3de0-11ea-81e4-9a2f10da1d55.png)


**Checklist:**
<!-- Replace  the [ ] with [x] to check the boxes --> 
- [x] My pull request has a descriptive title (not a vague title like "Update `index.md`").
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

**Legal**
By submitting this PR, I agree to abide by the terms of the Developer 
Certificate of Origin.

<details>
<summary>Developer Certificate of Origin</summary>

Developer Certificate of Origin<br>
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.<br>
1 Letterman Drive<br>
Suite D4700<br>
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
</details>
