### PR TITLE
Remove sizes styling from ImageView component styling

### DIFF
--- a/src/elements/ImageView.styl
+++ b/src/elements/ImageView.styl
@@ -1,6 +1,5 @@
 @import "../assets/tokens/tokens.styl"
 
-@import "../styles/sizes.styl"
 @import "../styles/media.styl"
 
 .vocab.image-view
@@ -22,31 +21,6 @@
     var(--image-view-overlay)
   )
 
-  // Measurement palette
-
-  &.small-sized
-    --image-view-measurement 2em
-
-  &.normal-sized
-    --image-view-measurement 4em
-
-  &.big-sized
-    --image-view-measurement 6em
-
-  &.large-sized
-    --image-view-measurement 8em
-
-  &.huge-sized
-    --image-view-measurement 12em
-
-  &.enormous-sized
-    --image-view-measurement 16em
-
-  &.gigantic-sized
-    --image-view-measurement 24em
-
-  &.mega-sized
-    --image-view-measurement 32em
 
   // Measurement
 


### PR DESCRIPTION
Fixes
<!-- If PR only partly solves the issue, replace 'Fixes' below with 'Partially addresses' -->
Fixes #58 by @annatuma 

**Description**
This removes Scaled style (sizes) from ImageView component

**Type of PR** 
This PR is a refactor.

**Screenshots**
<!-- If applicable, add screenshots to show the problem and the solution. -->**Checklist:**
<!-- Replace  the [ ] with [x] to check the boxes --> 
- [x] My pull request has a descriptive title (not a vague title like "Update `index.md`").
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

**Legal**
By submitting this PR, I agree to abide by the terms of the Developer 
Certificate of Origin.

<details>
<summary>Developer Certificate of Origin</summary>

Developer Certificate of Origin<br>
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.<br>
1 Letterman Drive<br>
Suite D4700<br>
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
</details>
