### PR TITLE
add markdown examples of note-plugin

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,7 @@
 module.exports = {
   stories: ['../src/**/*.stories.[tj]s'],
-  addons: ['@storybook/addon-knobs/register'],
+  addons: [
+    '@storybook/addon-knobs/register',
+    '@storybook/addon-notes/register'
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@babel/core": "^7.8.3",
     "@storybook/addon-knobs": "^5.3.9",
+    "@storybook/addon-notes": "^5.3.9",
     "@storybook/html": "^5.3.9",
     "babel-loader": "^8.0.6",
     "bulma": "^0.8.0",

--- a/src/stories/buttons.stories.js
+++ b/src/stories/buttons.stories.js
@@ -1,4 +1,11 @@
-export default { title: 'Buttons' };
+import ButtonNotes from './md/Buttons/Buttons.md';
+
+export default { 
+    title: 'Buttons',
+    parameters: {
+        notes: { ButtonNotes }
+    }
+};
 
 export const Button = () => '<button class="button big">Button</button>';
 

--- a/src/stories/md/Buttons/Buttons.md
+++ b/src/stories/md/Buttons/Buttons.md
@@ -1,0 +1,4 @@
+# Buttons notes
+this is an example of markdown format in `notes-plugin`
+
+this markdown file was 

--- a/src/stories/md/Typography/Considerations.md
+++ b/src/stories/md/Typography/Considerations.md
@@ -1,0 +1,5 @@
+# Font Considerations
+
+You can define different sections in the notes
+
+Inceptos adipiscing sit natoque dis tempor conubia habitant, at turpis fusce vehicula tempus mi, lorem semper pretium etiam porta non. Justo cum cras hac bibendum suspendisse nulla, netus natoque metus pharetra neque, nam ridiculus torquent amet tristique. Feugiat mi maecenas natoque montes tincidunt scelerisque class varius primis, consequat semper donec mollis bibendum cras posuere egestas, laoreet sed neque nisi est penatibus facilisi himenaeos.

--- a/src/stories/md/Typography/Specifications.md
+++ b/src/stories/md/Typography/Specifications.md
@@ -1,0 +1,11 @@
+# Typography specifications
+
+This is another section
+
+Hendrerit ornare magnis curabitur molestie natoque mattis malesuada ultricies montes, litora cubilia vestibulum imperdiet mus aptent hac purus, urna semper pellentesque congue himenaeos ligula nisl nascetur. Erat accumsan risus curae pharetra lobortis ultricies vel nec condimentum, habitant fames viverra parturient fermentum imperdiet facilisis curabitur. Gravida luctus congue curabitur natoque at sapien penatibus dictumst lorem pulvinar faucibus, in euismod nostra fermentum duis nisl conubia nisi id mus curae, purus sociosqu proin orci magnis hendrerit laoreet feugiat odio non.
+
+You can also define code blocks
+
+```html
+<h1 class="b-heading">This is a title</h1>
+```

--- a/src/stories/typography.stories.js
+++ b/src/stories/typography.stories.js
@@ -1,6 +1,18 @@
+import ConsiderationNotes from './md/Typography/Considerations.md';
+import SpecificationNotes from './md/Typography/Specifications.md';
+
 import { withKnobs, number, select } from '@storybook/addon-knobs';
 
-export default { title: 'Typography', decorators: [withKnobs] };
+export default { 
+    title: 'Typography', 
+    decorators: [withKnobs],
+    parameters: {
+        notes: {
+            Considerations: ConsiderationNotes,
+            Specifications: SpecificationNotes
+        }
+    }
+};
 
 const generateKnob = () => {
     const defaultValue = 1;


### PR DESCRIPTION
**Description**
This PR add Storybook's `note-plugin` to expand component documentation and avoid React dependency which `docs-plugins` has
Also, some markdown examples were added

**Type of PR** 
This PR is a feature.


**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like "Update `index.md`").
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

**Legal**
By submitting this PR, I agree to abide by the terms of the Developer 
Certificate of Origin.

<details>
<summary>Developer Certificate of Origin</summary>

Developer Certificate of Origin<br>
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.<br>
1 Letterman Drive<br>
Suite D4700<br>
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
</details>
