### PR TITLE
Update link color with $color-blue

### DIFF
--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -1,6 +1,6 @@
 // brand colors
 $color-turquoise: rgb(5, 181, 218);
-$color-tomato: rgb(237, 89, 47);
+$color-tomato: #ed592f;
 $color-gold: rgb(239, 190, 0);
 $color-orange: rgb(251, 119, 41);
 $color-blue: rgb(60, 92, 153);
@@ -39,7 +39,7 @@ $info: $color-forest;
 $success: $color-success;
 $warning: $color-warning;
 $danger: $color-error;
-$link: $color-turquoise;
+$link: $color-blue;
 $link-visited: $color-blue;
 
 $brand-colors: (


### PR DESCRIPTION
Fixes #122 

<img width="592" alt="Screen Shot 2020-02-12 at 15 51 40" src="https://user-images.githubusercontent.com/707019/74366992-d8cab400-4daf-11ea-9fc0-178ab722da01.png">
_more contrast in links compared to old color (see issue linked)_