### PR TITLE
Added a step to run 'watch' task to INSTRUCTIONS.md file

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -31,7 +31,7 @@ $ npm install
 ```
 
 **Step 4:**
-Instruct the webpack to compile the code whenever a file is updated within the dependency graph by running the `watch` task. 
+Watch Sass files for changes, and recompile stylesheets whenever a file is updated, by running the `watch` task. 
 
 ```
 $ npm run watch

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -31,7 +31,14 @@ $ npm install
 ```
 
 **Step 4:**
-Start the Vocabulary storybook by running the `storybook` task.
+Instruct the webpack to compile the code whenever a file is updated within the dependency graph by running the `watch` task. 
+
+```
+$ npm run watch
+```
+
+**Step 5:**
+Start the Vocabulary storybook by running the `storybook` task in a separate terminal window.
 
 ```
 $ npm run storybook


### PR DESCRIPTION
**Description**
A step to execute `npm run watch` was missing before `npm run storybook`. 

**Type of PR** 
This PR is a feature.

**Checklist:**
<!-- Replace  the [ ] with [x] to check the boxes --> 
- [x] My pull request has a descriptive title (not a vague title like "Update `index.md`").
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

**Legal**
By submitting this PR, I agree to abide by the terms of the Developer 
Certificate of Origin.

<details>
<summary>Developer Certificate of Origin</summary>

Developer Certificate of Origin<br>
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.<br>
1 Letterman Drive<br>
Suite D4700<br>
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
</details>
