### PR TITLE
Release new version compatible with @creativecommons/fonts@1.0.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creativecommons/vocabulary",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "A cohesive design system to unite the web facing Creative Commons",
   "author": "Creative Commons (https://creativecommons.org)",
   "scripts": {

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -1,4 +1,4 @@
-@import url("https://unpkg.com/@creativecommons/fonts@1.0.0-beta.1/dist/css/fonts.css");
+@import url("https://unpkg.com/@creativecommons/fonts@1.0.0-beta.2/css/fonts.css");
 @import url("https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700|Roboto+Condensed:400,700|Fira+Code:400");
 
 // Families


### PR DESCRIPTION
**Description**
This PR updates the package version to a new release supporting the newer cleaner CDN URL structure for `@creativecommons/fonts@1.0.0-beta.2`

**Type of PR**
<!-- Choose from one of these options -->
This PR is a refactor.

**Checklist:**
<!-- Replace  the [ ] with [x] to check the boxes --> 
- [x] My pull request has a descriptive title (not a vague title like "Update `index.md`").
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

**Legal**
By submitting this PR, I agree to abide by the terms of the Developer 
Certificate of Origin.

<details>
<summary>Developer Certificate of Origin</summary>

Developer Certificate of Origin<br>
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.<br>
1 Letterman Drive<br>
Suite D4700<br>
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
</details>
