### PR TITLE
tabs scss unit testing added

### DIFF
--- a/src/styles/tabs.scss
+++ b/src/styles/tabs.scss
@@ -8,14 +8,20 @@ $tabs-link-active-color: $color-dark-slate-gray;
 
 @import "../../node_modules/bulma/sass/components/tabs.sass";
 
+@mixin tab-control {
+   font-family: $family-source-sans-pro;
+}
+
 .tabs {
-  font-family: $family-source-sans-pro;
+  @include tab-control;
 
   a {
     font-size: $font-size-h5;
     font-weight: 700;
   }
 }
+
+
 
 .tabs-content {
   .tabs-panel {

--- a/tests/tests.scss
+++ b/tests/tests.scss
@@ -2,3 +2,4 @@
 @import '../src/styles/vocabulary.scss';
 
 @import './unit/dummy.scss';
+@import './unit/tabs.scss';

--- a/tests/unit/tabs.scss
+++ b/tests/unit/tabs.scss
@@ -1,0 +1,14 @@
+@import 'true';
+@import '../../src/styles/tabs.scss';
+@include describe('tabs()'){
+@include it('Outputs a font-family') {
+    @include assert {
+      @include output {
+        @include tab-control();
+      }
+      @include expect {
+        font-family: $family-source-sans-pro;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #165 by @dhruvkb 

## Description
<!-- Concisely describe what the pull request does. -->
This pull request aims at the addition of the unit testing for tabs component in vocabulary
## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
