### PR TITLE
Variables fixes to match Figma styles

### DIFF
--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -1,2 +1,5 @@
+$fullhd : 1248px + (2 * $gap);
+$column-gap: 3rem;
+
 @import "../../node_modules/bulma/sass/elements/container.sass";
 @import "../../node_modules/bulma/sass/grid/_all.sass";

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -39,7 +39,7 @@ $body-font-sizes: (
 
 @mixin body-typography($body-name, $body-font-size) {
   .body#{$body-name} {
-    line-height: 1.3;
+    line-height: $body-font-size * 1.6;
     font-size: $body-font-size;
   }
 }

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -39,7 +39,7 @@ $body-font-sizes: (
 
 @mixin body-typography($body-name, $body-font-size) {
   .body#{$body-name} {
-    line-height: $body-font-size * 1.6;
+    line-height: 1.6;
     font-size: $body-font-size;
   }
 }

--- a/tests/unit/typography-test.scss
+++ b/tests/unit/typography-test.scss
@@ -21,7 +21,7 @@
 
       @include expect {
         .body-standard {
-          line-height: 1.3;
+          line-height: 4.096rem;
           font-size: 2.56rem;
         }
       }

--- a/tests/unit/typography-test.scss
+++ b/tests/unit/typography-test.scss
@@ -21,7 +21,7 @@
 
       @include expect {
         .body-standard {
-          line-height: 4.096rem;
+          line-height: 1.6;
           font-size: 2.56rem;
         }
       }


### PR DESCRIPTION
## Description
This PR fix some Bulma's default values to match with Figma Design Library
- $fullhd size is now **1248px**
- $column-gap is now **3rem**
- Fix `line-height` on paragraph style classes because it looked tight

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
