### PR TITLE
Remove import guide from spacing docs

### DIFF
--- a/src/stories/spacing.stories.mdx
+++ b/src/stories/spacing.stories.mdx
@@ -28,9 +28,7 @@ largest ones like margin between sections.
 
 # Usage
 
-To use the spacings in your code, you can
-- use the helper classes in your markup for the most common use-cases
-- import `spacing.scss` and use the SCSS variables directly in your stylesheets
+To use the spacings in your code, you can use the helper classes in your markup for the most common use-cases
 
 Spacing applies to two properties (margin and padding) on four sides (top, right, bottom and left). For each spacing
 size and each property we have two kinds of helper classes:


### PR DESCRIPTION
Removed the spacing guide to use `import spacing.scss`. It's not particularly recommended in that case, since it's possible to do pretty much everything with the `margin` and `padding` classes.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
