### PR TITLE
Clean up Storybook configuration

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -7,6 +7,7 @@ module.exports = {
     'storybook-addon-designs',
     '@storybook/addon-knobs',
     '@storybook/addon-backgrounds',
+    '@storybook/addon-viewport',
     '@storybook/addon-docs'
   ]
 }

--- a/.storybook/order.js
+++ b/.storybook/order.js
@@ -1,0 +1,37 @@
+const order = {
+  'Vocabulary': [
+    'Introduction',
+    'Overview',
+    'Usage',
+    'Contribution'
+  ],
+  'Tokens': [
+    'Color',
+    'Typography',
+    'Spacing',
+    'Icons'
+  ],
+  'Assets': [],
+  'Elements': [],
+  'Form': [],
+  'Layouts': [],
+  'Patterns': []
+}
+const families = Object.keys(order)
+
+export default ([, one], [, two]) => {
+  if (one.kind === two.kind) {
+    return 0 // Sort stories in a component as defined in the MDX file
+  }
+  const [famOne, componentOne] = one.kind.split('/')
+  const [famTwo, componentTwo] = two.kind.split('/')
+  if (famOne === famTwo) {
+    if (order[famOne].length) {
+      return order[famOne].indexOf(componentOne) - order[famOne].indexOf(componentTwo)
+    } else {
+      return componentOne.localeCompare(componentTwo) // Sort components in a family in alphabetical order
+    }
+  } else {
+    return families.indexOf(famOne) - families.indexOf(famTwo) // Sort families according to defined order
+  }
+}

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,57 +1,27 @@
 import { addDecorator, addParameters, } from '@storybook/html'
 
-import { withKnobs } from '@storybook/addon-knobs'
 import { withDesign } from 'storybook-addon-designs'
+import { withKnobs } from '@storybook/addon-knobs'
+
+import viewports from './viewport'
+import order from './order'
 
 import '../dist/css/vocabulary.css'
-
-const order = {
-  'Vocabulary': [
-    'Introduction',
-    'Overview',
-    'Usage',
-    'Contribution'
-  ],
-  'Tokens': [
-    'Color',
-    'Typography',
-    'Spacing',
-    'Icons'
-  ],
-  'Assets': [],
-  'Elements': [],
-  'Form': [],
-  'Layouts': [],
-  'Patterns': []
-}
-const families = Object.keys(order)
 
 addParameters({
   options: {
     showRoots: true,
-    storySort: ([, one], [, two]) => {
-      if (one.kind === two.kind) {
-        return 0 // Sort stories in a component as defined in the MDX file
-      }
-      const [famOne, componentOne] = one.kind.split('/')
-      const [famTwo, componentTwo] = two.kind.split('/')
-      if (famOne === famTwo) {
-        if (order[famOne].length) {
-          return order[famOne].indexOf(componentOne) - order[famOne].indexOf(componentTwo)
-        } else {
-          return componentOne.localeCompare(componentTwo) // Sort components in a family in alphabetical order
-        }
-      } else {
-        return families.indexOf(famOne) - families.indexOf(famTwo) // Sort families according to defined order
-      }
-    }
+    storySort: order
   },
   backgrounds: [
     { name: 'canvas', value: '#f5f5f5', default: true },
     { name: 'white', value: '#ffffff' },
     { name: 'black', value: '#000000' }
-  ]
+  ],
+  viewport: {
+    viewports
+  }
 })
 
-addDecorator(withKnobs)
 addDecorator(withDesign)
+addDecorator(withKnobs)

--- a/.storybook/viewport.js
+++ b/.storybook/viewport.js
@@ -1,0 +1,201 @@
+// Configuration of addon-viewport
+
+export default {
+  // Mobiles
+  ClassicPhone: {
+    name: 'Classic phone',
+    styles: {
+      width: '320px',
+      height: '480px'
+    },
+    type: 'mobile'
+  },
+  iPhoneSE: {
+    name: 'Apple iPhone SE',
+    styles: {
+      width: '320px',
+      height: '568px'
+    },
+    type: 'mobile'
+  },
+  Note9: {
+    name: 'Samsung Galaxy Note 9',
+    styles: {
+      width: '360px',
+      height: '740px'
+    },
+    type: 'mobile'
+  },
+  iPhone6: {
+    name: 'Apple iPhone 6',
+    styles: {
+      width: '375px',
+      height: '667px'
+    },
+    type: 'mobile'
+  },
+  iPhone11Pro: {
+    name: 'Apple iPhone 11 Pro',
+    styles: {
+      width: '375px',
+      height: '812px'
+    },
+    type: 'mobile'
+  },
+  GooglePixel3: {
+    name: 'Google Pixel 3',
+    styles: {
+      width: '412px',
+      height: '824px'
+    },
+    type: 'mobile'
+  },
+  iPhone11: {
+    name: 'Apple iPhone 11',
+    styles: {
+      width: '414px',
+      height: '896px'
+    },
+    type: 'mobile'
+  },
+  iPhone11ProMax: {
+    name: 'Apple iPhone 11 Pro',
+    styles: {
+      width: '414px',
+      height: '896px'
+    },
+    type: 'mobile'
+  },
+
+  // Tablets
+  ClassicTablet: {
+    name: 'Classic tablet',
+    styles: {
+      width: '600px',
+      height: '800px'
+    },
+    type: 'tablet'
+  },
+  iPadMini: {
+    name: 'Apple iPad Mini 7.9"',
+    styles: {
+      width: '768px',
+      height: '1024px'
+    },
+    type: 'tablet'
+  },
+  iPad: {
+    name: 'Apple iPad 10.2"',
+    styles: {
+      width: '810px',
+      height: '1080px'
+    },
+    type: 'tablet'
+  },
+  iPadAir: {
+    name: 'Apple iPad Air 10.5"',
+    styles: {
+      width: '834px',
+      height: '1112px'
+    },
+    type: 'tablet'
+  },
+  iPadPro11: {
+    name: 'Apple iPad Pro 11"',
+    styles: {
+      width: '834px',
+      height: '1194px'
+    },
+    type: 'tablet'
+  },
+  iPadPro13: {
+    name: 'Apple iPad Pro 12.9"',
+    styles: {
+      width: '1024px',
+      height: '1366px'
+    },
+    type: 'tablet'
+  },
+
+  // Desktops
+  ClassicDesktop: {
+    name: 'Classic desktop',
+    styles: {
+      width: '1024px',
+      height: '768px'
+    },
+    type: 'monitor'
+  },
+  AsusChromebook: {
+    name: 'Asus Chrombook',
+    styles: {
+      width: '1280px',
+      height: '800px'
+    },
+    type: 'monitor'
+  },
+  MacBookPro12: {
+    name: 'Apple MacBook Pro 12"',
+    styles: {
+      width: '1280px',
+      height: '800px'
+    },
+    type: 'monitor'
+  },
+  AcerChromebook: {
+    name: 'Acer Chromebook',
+    styles: {
+      width: '1366px',
+      height: '768px'
+    },
+    type: 'monitor'
+  },
+  MacBookPro15: {
+    name: 'Apple MacBook Pro 15"',
+    styles: {
+      width: '1440px',
+      height: '900px'
+    },
+    type: 'monitor'
+  },
+  MacBookPro16: {
+    name: 'Apple MacBook Pro 16"',
+    styles: {
+      width: '1536px',
+      height: '960px'
+    },
+    type: 'monitor'
+  },
+  DellXPS13: {
+    name: 'Dell XPS 13',
+    styles: {
+      width: '1920px',
+      height: '1080px'
+    },
+    type: 'monitor'
+  },
+  SurfaceProX: {
+    name: 'Microsoft Surface Pro X',
+    styles: {
+      width: '2880px',
+      height: '1920px'
+    },
+    type: 'monitor'
+  },
+  SurfaceBook213: {
+    name: 'Microsoft Surface Book 2 13.5"',
+    styles: {
+      width: '3000px',
+      height: '2000px'
+    },
+    type: 'monitor'
+  },
+  SurfaceBook215: {
+    name: 'Microsoft Surface Book 2 15"',
+    styles: {
+      width: '3240px',
+      height: '2160px'
+    },
+    type: 'monitor'
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3796,6 +3796,25 @@
         }
       }
     },
+    "@storybook/addon-viewport": {
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-5.3.17.tgz",
+      "integrity": "sha512-tkf9XyzT4Ld3bcJaNqczZo3Wll6j/DVyf6lEcCp4XD4dor7eQEIxCBVU3LR+2zeLqhWxBHtPmL1SxYVPpcZR6A==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "5.3.17",
+        "@storybook/api": "5.3.17",
+        "@storybook/client-logger": "5.3.17",
+        "@storybook/components": "5.3.17",
+        "@storybook/core-events": "5.3.17",
+        "@storybook/theming": "5.3.17",
+        "core-js": "^3.0.1",
+        "global": "^4.3.2",
+        "memoizerific": "^1.11.3",
+        "prop-types": "^15.7.2",
+        "util-deprecate": "^1.0.2"
+      }
+    },
     "@storybook/addons": {
       "version": "5.3.17",
       "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.3.17.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@storybook/addon-backgrounds": "^5.3.17",
     "@storybook/addon-docs": "^5.3.17",
     "@storybook/addon-knobs": "^5.3.17",
+    "@storybook/addon-viewport": "^5.3.17",
     "@storybook/html": "^5.3.17",
     "babel-jest": "^25.2.3",
     "babel-loader": "^8.0.6",


### PR DESCRIPTION
## Description
Adds the Viewport addon to the Storybook to examine components as they wood render at various screen sizes. Also cleans up the Storybook configuration under the hood to be cleaner and more modular.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
