### PR TITLE
Fix bulma imports

### DIFF
--- a/src/styles/button.scss
+++ b/src/styles/button.scss
@@ -1,6 +1,6 @@
 $button-family: $family-alternative;
 
-@import "../../node_modules/bulma/sass/elements/button.sass";
+@import "bulma/sass/elements/button.sass";
 
 .button {
   text-transform: uppercase;

--- a/src/styles/card.scss
+++ b/src/styles/card.scss
@@ -2,7 +2,7 @@ $card-shadow : none;
 $card-content-padding: $space-big;
 $card-header-shadow: none;
 
-@import "../../node_modules/bulma/sass/components/card.sass";
+@import "bulma/sass/components/card.sass";
 
 .card {
     &.entry-post {

--- a/src/styles/color.scss
+++ b/src/styles/color.scss
@@ -73,5 +73,5 @@ $brand-colors: (
   @include color-classes($color-namespace, $brand-color);
 };
 
-@import "../../node_modules/bulma/sass/utilities/_all.sass";
-@import "../../node_modules/bulma/sass/base/_all.sass";
+@import "bulma/sass/utilities/_all.sass";
+@import "bulma/sass/base/_all.sass";

--- a/src/styles/form.scss
+++ b/src/styles/form.scss
@@ -9,7 +9,7 @@ $input-active-border-color: $color-gray;
 
 $input-disabled-border-color: $color-gray;
 
-@import "../../node_modules/bulma/sass/form/_all.sass";
+@import "bulma/sass/form/_all.sass";
 
 // Form control
 @mixin form_control {

--- a/src/styles/global_header.scss
+++ b/src/styles/global_header.scss
@@ -1,4 +1,4 @@
-@import "../../node_modules/bulma/sass/components/level.sass";
+@import "bulma/sass/components/level.sass";
 
 .cc-global-header {
   background-color: $color-black;

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -7,7 +7,7 @@ $navbar-item-hover-background-color: transparent;
 $navbar-dropdown-border-top: none;
 $navbar-dropdown-radius: 0;
 
-@import "../../node_modules/bulma/sass/components/navbar.sass";
+@import "bulma/sass/components/navbar.sass";
 
 .navbar {
   padding: $space-bigger;

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -1,5 +1,5 @@
 $fullhd : 1248px + (2 * $gap);
 $column-gap: 3rem;
 
-@import "../../node_modules/bulma/sass/elements/container.sass";
-@import "../../node_modules/bulma/sass/grid/_all.sass";
+@import "bulma/sass/elements/container.sass";
+@import "bulma/sass/grid/_all.sass";

--- a/src/styles/table.scss
+++ b/src/styles/table.scss
@@ -3,7 +3,7 @@ $table-color: $color-dark-slate-gray;
 $table-head-background-color: $color-light-gray;
 
 
-@import "../../node_modules/bulma/sass/elements/table.sass";
+@import "bulma/sass/elements/table.sass";
 
 .number-cell {
   text-align: right !important;

--- a/src/styles/tabs.scss
+++ b/src/styles/tabs.scss
@@ -6,7 +6,7 @@ $tabs-link-hover-color: $color-dark-slate-gray;
 $tabs-link-active-border-bottom-color: $color-dark-slate-gray;
 $tabs-link-active-color: $color-dark-slate-gray;
 
-@import "../../node_modules/bulma/sass/components/tabs.sass";
+@import "bulma/sass/components/tabs.sass";
 
 .tabs {
   font-family: $family-source-sans-pro;

--- a/tests/unit/sass.test.js
+++ b/tests/unit/sass.test.js
@@ -1,5 +1,13 @@
 import path from 'path'
 import sassTrue from 'sass-true'
 
+function importer (url, prev, done) {
+  if (url.indexOf('bulma') >= 0) {
+    url = path.resolve('node_modules', url)
+  }
+
+  return { file: url }
+}
+
 const sassFile = path.join(__dirname, 'setup_tests.scss')
-sassTrue.runSass({ file: sassFile }, { describe, it })
+sassTrue.runSass({ importer, file: sassFile }, { describe, it })


### PR DESCRIPTION
This fixes an issue with the bulma imports. The path was hardcoded with the `../../node_modules` absolute path, when it should use just `bulma/sass/<file.sass>`. This way, on projects that use Vocabulary and import the `vocabulary.scss` the import paths will use the global dependency paths that that webpack will use to find the dependencies, and not use a fixed path that can break on clients of Vocabulary

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
