### PR TITLE
Fixed preserveAspectRatio xMidYMid

### DIFF
--- a/.storybook/meta/usage.stories.mdx
+++ b/.storybook/meta/usage.stories.mdx
@@ -42,7 +42,7 @@ You can reference assets using file loader or SVG inline loader.
 <svg
   class="logo"
   xmlns="http://www.w3.org/2000/svg"
-  preserveAspectRatio="xMidyMid meet"
+  preserveAspectRatio="xMidYMid meet"
   viewBox="0 0 304 73">
   <use href="@creativecommons/vocabulary/assets/logos/cc/logomark.svg#creativecommons"></use>
 </svg>
@@ -109,7 +109,7 @@ directly be hotlinked from the CDNs due to cross-origin issues, you'll need to a
 
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  preserveAspectRatio="xMidyMid meet"
+  preserveAspectRatio="xMidYMid meet"
   viewBox="0 0 304 73">
   <!-- Automatically finds ID amongst all assets loaded using `patchAssetIntoDom()` -->
   <use href="#creativecommons"></use>

--- a/src/assets/logos/cc/letterheart.svg
+++ b/src/assets/logos/cc/letterheart.svg
@@ -1,6 +1,6 @@
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  preserveAspectRatio="xMidyMid meet"
+  preserveAspectRatio="xMidYMid meet"
   viewBox="0 0 80 72">
   <g id="letterheart" fill="currentColor">
     <path

--- a/src/assets/logos/cc/lettermark.svg
+++ b/src/assets/logos/cc/lettermark.svg
@@ -1,6 +1,6 @@
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  preserveAspectRatio="xMidyMid meet"
+  preserveAspectRatio="xMidYMid meet"
   viewBox="0 0 72 72">
   <g id="lettermark" fill="currentColor">
     <path

--- a/src/assets/logos/cc/logomark.svg
+++ b/src/assets/logos/cc/logomark.svg
@@ -1,6 +1,6 @@
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  preserveAspectRatio="xMidyMid meet"
+  preserveAspectRatio="xMidYMid meet"
   viewBox="0 0 304 73">
   <g id="logomark" fill="currentColor">
     <path

--- a/src/assets/logos/products/certificates.svg
+++ b/src/assets/logos/products/certificates.svg
@@ -1,6 +1,6 @@
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  preserveAspectRatio="xMidyMid meet"
+  preserveAspectRatio="xMidYMid meet"
   viewBox="0 0 160 174">
   <g id="certificates" fill="currentColor">
     <path

--- a/src/assets/logos/products/global_network.svg
+++ b/src/assets/logos/products/global_network.svg
@@ -1,6 +1,6 @@
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  preserveAspectRatio="xMidyMid meet"
+  preserveAspectRatio="xMidYMid meet"
   viewBox="0 0 250 79">
   <g id="globalnetwork" fill="currentColor">
     <path

--- a/src/assets/logos/products/open_source.svg
+++ b/src/assets/logos/products/open_source.svg
@@ -1,6 +1,6 @@
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  preserveAspectRatio="xMidyMid meet"
+  preserveAspectRatio="xMidYMid meet"
   viewBox="0 0 250 76">
   <g id="opensource" fill="currentColor">
     <path

--- a/src/assets/logos/products/search.svg
+++ b/src/assets/logos/products/search.svg
@@ -1,6 +1,6 @@
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  preserveAspectRatio="xMidyMid meet"
+  preserveAspectRatio="xMidYMid meet"
   viewBox="0 0 250 81">
   <g id="search" fill="currentColor">
     <path

--- a/src/assets/logos/products/vocabulary.svg
+++ b/src/assets/logos/products/vocabulary.svg
@@ -1,6 +1,6 @@
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  preserveAspectRatio="xMidyMid meet"
+  preserveAspectRatio="xMidYMid meet"
   viewBox="0 0 250 41">
   <g id="vocabulary" fill="currentColor">
     <path

--- a/src/stories/header.stories.mdx
+++ b/src/stories/header.stories.mdx
@@ -13,7 +13,7 @@ export const header = (size, color) => `<header>
             <svg
               class="logo"
               xmlns="http://www.w3.org/2000/svg"
-              preserveAspectRatio="xMidyMid meet"
+              preserveAspectRatio="xMidYMid meet"
               viewBox="0 0 304 73">
               <use href="logos/cc/logomark.svg#logomark"></use>
             </svg>

--- a/src/stories/logos.stories.mdx
+++ b/src/stories/logos.stories.mdx
@@ -9,7 +9,7 @@ import { figmaConfig } from './helpers'
 
 export const svgCode = (viewBoxX, viewBoxY, fileName, id) => `<svg
   xmlns="http://www.w3.org/2000/svg"
-  preserveAspectRatio="xMidyMid meet"
+  preserveAspectRatio="xMidYMid meet"
   viewBox="0 0 ${viewBoxX} ${viewBoxY}">
   <use href="logos/${fileName}.svg#${id}"></use>
 </svg>`
@@ -177,7 +177,7 @@ ${svgCode(250, 81, 'products/search', 'search')}`
 export const certificates = (type) => `<style>svg { height: 174px; }</style>
 <svg
   xmlns="http://www.w3.org/2000/svg"
-  preserveAspectRatio="xMidyMid meet"
+  preserveAspectRatio="xMidYMid meet"
   viewBox="0 0 160 174">
   <use href="logos/products/certificates.svg#certificates"></use>
   <use href="logos/products/certificates.svg#${type}_dots"></use>


### PR DESCRIPTION
Fixed typo in preserveAspectRatio attribute in SVGs that was causing this error:

`<svg> attribute preserveAspectRatio: Unrecognized enumerated value, "xMidyMid meet".`.
Correct value is `xMidYMid` (capital Y). See [docs](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/preserveAspectRatio)

You can see it in https://ccsearch-dev.creativecommons.org/.


## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
