### PR TITLE
Cache node modules to improve CI workflow speed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,18 @@ jobs:
       with:
         node-version: '12.16.1'
 
+    - id: cache-npm-folder
+      name: Cache npm-cache installation folder
+      uses: actions/cache@v1
+      with:
+        path: ~/.npm  # npm caches files in ~/.npm
+        key: node-${{ hashFiles('**/package-lock.json') }}
+
     - id: cache-node-modules
       name: Cache Node.js modules
       uses: actions/cache@v1
       with:
-        path: ~/.npm  # npm caches files in ~/.npm
+        path: ./node_modules  # cache Node Modules in ./node_modules folder
         key: node-${{ hashFiles('**/package-lock.json') }}
 
     - name: Install dependencies
@@ -49,14 +56,22 @@ jobs:
       with:
         node-version: '12.16.1'
 
-    - id: cache-node-modules
-      name: Cache Node.js modules
+    - id: cache-npm-folder
+      name: Cache npm-cache installation folder
       uses: actions/cache@v1
       with:
         path: ~/.npm  # npm caches files in ~/.npm
         key: node-${{ hashFiles('**/package-lock.json') }}
 
+    - id: cache-node-modules
+      name: Cache Node.js modules
+      uses: actions/cache@v1
+      with:
+        path: ./node_modules  # cache Node Modules in ./node_modules folder
+        key: node-${{ hashFiles('**/package-lock.json') }}
+
     - name: Install dependencies
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
       run: npm install --prefer-offline --no-audit
 
     - name: Run lint
@@ -75,14 +90,22 @@ jobs:
       with:
         node-version: '12.16.1'
 
-    - id: cache-node-modules
-      name: Cache Node.js modules
+    - id: cache-npm-folder
+      name: Cache npm-cache installation folder
       uses: actions/cache@v1
       with:
         path: ~/.npm  # npm caches files in ~/.npm
         key: node-${{ hashFiles('**/package-lock.json') }}
 
+    - id: cache-node-modules
+      name: Cache Node.js modules
+      uses: actions/cache@v1
+      with:
+        path: ./node_modules  # cache Node Modules in ./node_modules folder
+        key: node-${{ hashFiles('**/package-lock.json') }}
+
     - name: Install dependencies
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
       run: npm install --prefer-offline --no-audit
 
     - name: Run tests
@@ -101,8 +124,8 @@ jobs:
       with:
         node-version: '12.16.1'
 
-    - id: cache-node-modules
-      name: Cache Node.js modules
+    - id: cache-npm-folder
+      name: Cache npm-cache installation folder
       uses: actions/cache@v1
       with:
         path: ~/.npm  # npm caches files in ~/.npm
@@ -115,7 +138,15 @@ jobs:
         path: ./dist  # build script puts compiled files in ./dist
         key: dist-${{ github.sha }}
 
+    - id: cache-node-modules
+      name: Cache Node.js modules
+      uses: actions/cache@v1
+      with:
+        path: ./node_modules  # cache Node Modules in ./node_modules folder
+        key: node-${{ hashFiles('**/package-lock.json') }}
+    
     - name: Install dependencies
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
       run: npm install --prefer-offline --no-audit
 
     - name: Run build


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #331 by @dhruvkb

## Description
<!-- Concisely describe what the pull request does. -->
With this PR, in the CI workflow, the node modules will be installed and cached in the `Setup`job if there is a change in `package-lock.json` file. Then in subsequent jobs to `lint`, `unit tests` and `build`, the node modules won't be installed but be restored from the cache. It is expected that with this approach, the workflow run time will improve by about 45 seconds for each workflow run.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
