### PR TITLE
Add helper classes for feedback colors

### DIFF
--- a/src/stories/color.stories.mdx
+++ b/src/stories/color.stories.mdx
@@ -128,7 +128,7 @@ To use the colors in your code, you can
 - use the helper classes in your markup for the most common use-cases
 - import `colors.scss` and use the SCSS variables directly in your stylesheets
 
-For each of the brand colors, we have two helper classes:
+For each of the brand and feedback colors, we have two helper classes:
 - `.has-background-<color>`<br/>
   Applies the color as the background color for the element.
 - `.has-text-<color>` or `.has-color-<color>`<br/>

--- a/src/styles/color.scss
+++ b/src/styles/color.scss
@@ -49,6 +49,17 @@ $link: $color-tomato;
 $link-visited: $color-tomato;
 
 // Classes
+@mixin color-classes($color-namespace, $brand-color) {
+  .has-background-#{$color-namespace} {
+    background-color: $brand-color;
+  }
+
+  .has-text-#{$color-namespace}, // Bulma convention
+  .has-color-#{$color-namespace} {
+    color: $brand-color;
+  }
+}
+
 $brand-colors: (
   "tomato": $color-tomato,
   "orange": $color-orange,
@@ -58,19 +69,20 @@ $brand-colors: (
   "dark-slate-blue": $color-dark-slate-blue,
   "dark-slate-gray": $color-dark-slate-gray);
 
-@mixin color-classes($color-namespace, $brand-color) {
-  .has-background-#{$color-namespace} {
-    background-color: $brand-color;
-  }
-  
-  .has-text-#{$color-namespace}, // Bulma convention
-  .has-color-#{$color-namespace} {
-    color: $brand-color;
-  }
-}
-
 @each $color-namespace, $brand-color in $brand-colors {
   @include color-classes($color-namespace, $brand-color);
+};
+
+$feedback-colors: (
+  "dark-success": $color-dark-success,
+  "light-success": $color-light-success,
+  "dark-warning": $color-dark-warning,
+  "light-warning": $color-light-warning,
+  "dark-error": $color-dark-error,
+  "light-error": $color-light-error);
+
+@each $color-namespace, $feedback-color in $feedback-colors {
+  @include color-classes($color-namespace, $feedback-color);
 };
 
 @import "bulma/sass/utilities/_all.sass";


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
This PR adds helper classes like `.has-background-<color>` and `.has-text-<color>` for the feedback colors (success, warning and error).

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
The PR uses the existing mixin, extending its use to the feedback colors.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
