### PR TITLE
Extra padding in the Rich Content Table. #358

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@creativecommons/vocabulary",
-  "version": "1.0.0-beta.13",
+  "version": "1.0.0-beta.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/stories/image.stories.mdx
+++ b/src/stories/image.stories.mdx
@@ -14,7 +14,7 @@ image within the content, it should follow the grid columns.
     design: figmaConfig('576%3A1')}}>{`
     <div class="image" style="max-width: 512px;">
       <img src="demo/broadway_tower.jpg">
-      <div class="image-title">
+      <div class="image-title" style="text-overflow: ellipsis">
         Broadway Tower
       </div>
       <div class="image-icons">

--- a/src/stories/tables.stories.mdx
+++ b/src/stories/tables.stories.mdx
@@ -45,7 +45,7 @@ import { figmaConfig } from './helpers'
         <td class="number-cell">4</td>
       </tr>
     </table>
-  `}</Story>
+    `}</Story>
 </Preview>
 
 ## Rich Content Table
@@ -64,11 +64,11 @@ import { figmaConfig } from './helpers'
         </tr>
       </thead>
       <tr>
-        <td class="padding-vertical-normal padding-right-xl padding-left-normal">
+        <td class="padding-vertical-normal padding-left-normal">
           <div class="text-bigger has-text-weight-bold padding-bottom-smaller">CC Search</div>
           <div>7 contributors</div>
         </td>
-        <td class="padding-vertical-normal padding-right-xl padding-left-normal">
+        <td class="padding-vertical-normal padding-left-normal">
           <a href="#" class="is-block">Mockups</a>
           <a href="#" class="is-block">Project Brief</a>
           <a href="#" class="is-block">Drive Folder</a>
@@ -79,11 +79,11 @@ import { figmaConfig } from './helpers'
         <td>13/01/2020</td>
       </tr>
       <tr>
-        <td class="padding-vertical-normal padding-right-xl padding-left-normal">
+        <td class="padding-vertical-normal padding-left-normal">
           <div class="text-bigger has-text-weight-bold padding-bottom-smaller">CC License Chooser</div>
           <div>7 contributors</div>
         </td>
-        <td class="padding-vertical-normal padding-right-xl padding-left-normal">
+        <td class="padding-vertical-normal padding-left-normal">
           <a href="#" class="is-block">Mockups</a>
         </td>
         <td class="has-text-right">
@@ -92,11 +92,11 @@ import { figmaConfig } from './helpers'
         <td>13/01/2020</td>
       </tr>
       <tr>
-        <td class="padding-vertical-normal padding-right-xl padding-left-normal">
+        <td class="padding-vertical-normal padding-left-normal">
           <div class="text-bigger has-text-weight-bold padding-bottom-smaller">Open Source Redesign</div>
           <div>7 contributors</div>
         </td>
-        <td class="padding-vertical-normal padding-right-xl padding-left-normal">
+        <td class="padding-vertical-normal padding-left-normal">
           <a href="#" class="is-block">Test sessions</a>
           <a href="#" class="is-block">Content</a>
         </td>
@@ -106,5 +106,5 @@ import { figmaConfig } from './helpers'
         <td>13/01/2020</td>
       </tr>
     </table>
-  `}</Story>
+    `}</Story>
 </Preview>

--- a/src/stories/tables.stories.mdx
+++ b/src/stories/tables.stories.mdx
@@ -106,5 +106,5 @@ import { figmaConfig } from './helpers'
         <td>13/01/2020</td>
       </tr>
     </table>
-    `}</Story>
+  `}</Story>
 </Preview>

--- a/src/stories/tables.stories.mdx
+++ b/src/stories/tables.stories.mdx
@@ -68,7 +68,7 @@ import { figmaConfig } from './helpers'
           <div class="text-bigger has-text-weight-bold padding-bottom-smaller">CC Search</div>
           <div>7 contributors</div>
         </td>
-        <td class="padding-vertical-normal padding-left-normal">
+        <td class="padding-vertical-normal padding-right-xl padding-left-normal">
           <a href="#" class="is-block">Mockups</a>
           <a href="#" class="is-block">Project Brief</a>
           <a href="#" class="is-block">Drive Folder</a>
@@ -83,7 +83,7 @@ import { figmaConfig } from './helpers'
           <div class="text-bigger has-text-weight-bold padding-bottom-smaller">CC License Chooser</div>
           <div>7 contributors</div>
         </td>
-        <td class="padding-vertical-normal padding-left-normal">
+        <td class="padding-vertical-normal padding-right-xl padding-left-normal">
           <a href="#" class="is-block">Mockups</a>
         </td>
         <td class="has-text-right">
@@ -96,7 +96,7 @@ import { figmaConfig } from './helpers'
           <div class="text-bigger has-text-weight-bold padding-bottom-smaller">Open Source Redesign</div>
           <div>7 contributors</div>
         </td>
-        <td class="padding-vertical-normal padding-left-normal">
+        <td class="padding-vertical-normal padding-right-xl padding-left-normal">
           <a href="#" class="is-block">Test sessions</a>
           <a href="#" class="is-block">Content</a>
         </td>


### PR DESCRIPTION
## Fixes
Extra padding in the Rich Content Table
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #358  by @larrysul

## Description
Comparing the Figma design and the story, there seems to exist extra padding in the first column of the Rich Content table.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
