### PR TITLE
Bump package to version 15

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,6 +1,3 @@
-<!-- Fira Code for code snippets -->
-<link rel="stylesheet" href="//fonts.googleapis.com/css?family=Fira+Code:400" type="text/css" media="all">
-
 <style>
   html {
     background-color: unset !important;

--- a/.storybook/theme.js
+++ b/.storybook/theme.js
@@ -18,7 +18,7 @@ export default create({
 
   // Typography
   fontBase: '"Source Sans Pro", sans-serif',
-  fontCode: '"Fira Code", monospace',
+  fontCode: '"JetBrains Mono", monospace',
 
   // Text colors
   textColor: 'rgb(0, 0, 0)',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@creativecommons/vocabulary",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creativecommons/vocabulary",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "A cohesive design system to unite the web facing Creative Commons",
   "author": "Creative Commons (https://creativecommons.org)",
   "scripts": {

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -1,9 +1,9 @@
-@import url("https://unpkg.com/@creativecommons/fonts@1.0.0-beta.8/css/fonts.css");
+@import url("https://unpkg.com/@creativecommons/fonts@1.0.0-beta.9/css/fonts.css");
 
 // Families
 $family-roboto-condensed: 'Roboto Condensed', sans-serif;
 $family-source-sans-pro: 'Source Sans Pro', sans-serif;
-$family-fira-code: monospace; // Maybe later
+$family-jetbrains-mono: 'JetBrains Mono', monospace;
 $family-system: BlinkMacSystemFont, -apple-system, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
 'Droid Sans', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
 
@@ -27,7 +27,7 @@ $font-size-caption: 0.8rem;
 // Overrides
 $family-sans-serif: $family-source-sans-pro;
 $family-alternative: $family-roboto-condensed;
-$family-monospace: $family-fira-code;
+$family-monospace: $family-jetbrains-mono;
 
 // Classes
 $body-font-sizes: (
@@ -63,7 +63,7 @@ $body-font-sizes: (
 
 .monospace {
   font-family: $family-monospace;
-  font-size: 0.875em; // Fira Code at 14px is similar to other fonts at 16px
+  font-size: 0.875em; // Code fonts at 14px are similar to other fonts at 16px
 }
 
 // Usage


### PR DESCRIPTION
## Description
Release version 15 of Vocabulary, corresponding to version 9 of Fonts.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
