### PR TITLE
Override Bulma variables with Vocabulary's token values

### DIFF
--- a/src/styles/button.scss
+++ b/src/styles/button.scss
@@ -1,4 +1,4 @@
-$button-family: $family-alternative;
+$button-family: $family-secondary;
 
 @import "bulma/sass/elements/button.sass";
 

--- a/src/styles/color.scss
+++ b/src/styles/color.scss
@@ -38,7 +38,7 @@ $brand-colors: (
   "forest-green": $color-forest-green,
   "dark-turquoise": $color-dark-turquoise,
   "dark-slate-blue": $color-dark-slate-blue,
-  "dark-slate-gray": $color-dark-slate-gray,
+  "dark-slate-gray": $color-dark-slate-gray
 );
 
 @mixin color-classes($color-namespace, $brand-color) {

--- a/src/styles/color.scss
+++ b/src/styles/color.scss
@@ -32,26 +32,26 @@ $color-light-error: rgb(255, 201, 201);
 
 // Classes
 $brand-colors: (
-	"tomato": $color-tomato,
-	"orange": $color-orange,
-	"gold": $color-gold,
-	"forest-green": $color-forest-green,
-	"dark-turquoise": $color-dark-turquoise,
-	"dark-slate-blue": $color-dark-slate-blue,
-	"dark-slate-gray": $color-dark-slate-gray,
+  "tomato": $color-tomato,
+  "orange": $color-orange,
+  "gold": $color-gold,
+  "forest-green": $color-forest-green,
+  "dark-turquoise": $color-dark-turquoise,
+  "dark-slate-blue": $color-dark-slate-blue,
+  "dark-slate-gray": $color-dark-slate-gray,
 );
 
 @mixin color-classes($color-namespace, $brand-color) {
-	.has-background-#{$color-namespace} {
-		background-color: $brand-color;
-	}
+  .has-background-#{$color-namespace} {
+    background-color: $brand-color;
+  }
 
-	.has-text-#{$color-namespace}, // Bulma convention
+  .has-text-#{$color-namespace}, // Bulma convention
   .has-color-#{$color-namespace} {
-		color: $brand-color;
-	}
+    color: $brand-color;
+  }
 }
 
 @each $color-namespace, $brand-color in $brand-colors {
-	@include color-classes($color-namespace, $brand-color);
+  @include color-classes($color-namespace, $brand-color);
 }

--- a/src/styles/color.scss
+++ b/src/styles/color.scss
@@ -30,45 +30,28 @@ $color-light-warning: rgb(250, 236, 188);
 $color-dark-error: rgb(200, 59, 30);
 $color-light-error: rgb(255, 201, 201);
 
-// Overrides
-$red: $color-tomato;
-$orange: $color-orange;
-$yellow: $color-gold;
-$green: $color-forest-green;
-$cyan: $color-dark-slate-blue;
-$blue: $color-dark-slate-blue;
-
-$primary: $color-tomato;
-
-$success: $color-dark-success;
-$info: $color-forest-green;
-$warning: $color-dark-warning;
-$danger: $color-dark-error;
-
-$link: $color-tomato;
-$link-visited: $color-tomato;
-
 // Classes
 $brand-colors: (
-  "tomato": $color-tomato,
-  "orange": $color-orange,
-  "gold": $color-gold,
-  "forest-green": $color-forest-green,
-  "dark-turquoise": $color-dark-turquoise,
-  "dark-slate-blue": $color-dark-slate-blue,
-  "dark-slate-gray": $color-dark-slate-gray);
+	"tomato": $color-tomato,
+	"orange": $color-orange,
+	"gold": $color-gold,
+	"forest-green": $color-forest-green,
+	"dark-turquoise": $color-dark-turquoise,
+	"dark-slate-blue": $color-dark-slate-blue,
+	"dark-slate-gray": $color-dark-slate-gray,
+);
 
 @mixin color-classes($color-namespace, $brand-color) {
-  .has-background-#{$color-namespace} {
-    background-color: $brand-color;
-  }
+	.has-background-#{$color-namespace} {
+		background-color: $brand-color;
+	}
 
-  .has-text-#{$color-namespace}, // Bulma convention
+	.has-text-#{$color-namespace}, // Bulma convention
   .has-color-#{$color-namespace} {
-    color: $brand-color;
-  }
+		color: $brand-color;
+	}
 }
 
 @each $color-namespace, $brand-color in $brand-colors {
-  @include color-classes($color-namespace, $brand-color);
-};
+	@include color-classes($color-namespace, $brand-color);
+}

--- a/src/styles/color_overrides.scss
+++ b/src/styles/color_overrides.scss
@@ -1,14 +1,3 @@
-// For typography
-$family-sans-serif: $family-source-sans-pro;
-$family-alternative: $family-roboto-condensed;
-$family-monospace: $family-jetbrains-mono;
-
-$size-4: $font-size-body-bigger;
-$size-5: $font-size-body-big;
-$size-6: $font-size-body-normal;
-$size-7: $font-size-caption;
-
-// For colors
 $red: $color-tomato;
 $orange: $color-orange;
 $yellow: $color-gold;

--- a/src/styles/color_overrides.scss
+++ b/src/styles/color_overrides.scss
@@ -1,21 +1,22 @@
-$red: $color-tomato;
-$orange: $color-orange;
-$yellow: $color-gold;
-$green: $color-forest-green;
-$cyan: $color-dark-slate-blue;
-$blue: $color-dark-slate-blue;
-$turquoise: $color-dark-turquoise;
-$white: $color-white;
 $black: $color-black;
+$grey-dark: $color-dark-gray;
 $grey: $color-gray;
 $grey-light: $color-light-gray;
 $grey-lighter: $color-lighter-gray;
-$grey-dark: $color-dark-gray;
+$white: $color-white;
+
+$orange: $color-orange;
+$yellow: $color-gold;
+$green: $color-forest-green;
+$turquoise: $color-dark-turquoise;
+$cyan: $color-dark-slate-blue;
+$blue: $color-dark-slate-blue;
+$red: $color-tomato;
 
 $primary: $color-tomato;
 
-$success: $color-dark-success;
 $info: $color-forest-green;
+$success: $color-dark-success;
 $warning: $color-dark-warning;
 $danger: $color-dark-error;
 

--- a/src/styles/footer.scss
+++ b/src/styles/footer.scss
@@ -41,7 +41,7 @@
         .menu-item {
           display: block;
           padding: $space-normal;
-          font-family: $family-alternative;
+          font-family: $family-secondary;
           font-size: $font-size-h6;
           font-weight: 600;
           text-transform: uppercase;

--- a/src/styles/overrides.scss
+++ b/src/styles/overrides.scss
@@ -1,0 +1,34 @@
+// For typography
+$family-sans-serif: $family-source-sans-pro;
+$family-alternative: $family-roboto-condensed;
+$family-monospace: $family-jetbrains-mono;
+
+$size-4: $font-size-body-bigger;
+$size-5: $font-size-body-big;
+$size-6: $font-size-body-normal;
+$size-7: $font-size-caption;
+
+// For colors
+$red: $color-tomato;
+$orange: $color-orange;
+$yellow: $color-gold;
+$green: $color-forest-green;
+$cyan: $color-dark-slate-blue;
+$blue: $color-dark-slate-blue;
+$turquoise: $color-dark-turquoise;
+$white: $color-white;
+$black: $color-black;
+$grey: $color-gray;
+$grey-light: $color-light-gray;
+$grey-lighter: $color-lighter-gray;
+$grey-dark: $color-dark-gray;
+
+$primary: $color-tomato;
+
+$success: $color-dark-success;
+$info: $color-forest-green;
+$warning: $color-dark-warning;
+$danger: $color-dark-error;
+
+$link: $color-tomato;
+$link-visited: $color-tomato;

--- a/src/styles/pagination.scss
+++ b/src/styles/pagination.scss
@@ -14,7 +14,7 @@ $pagination-ellipsis-color: $color-dark-gray;
   .pagination-list {
     .common {
       font-weight: bold;
-      font-family: $family-alternative;
+      font-family: $family-secondary;
       line-height: 1.875;
 
       .common-link {

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -63,12 +63,7 @@ $body-font-sizes: (
 }
 
 // Usage
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+h1, h2, h3, h4, h5, h6 {
   color: $color-dark-slate-gray;
 
   font-family: $family-roboto-condensed;

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -1,12 +1,12 @@
 @import url("https://unpkg.com/@creativecommons/fonts@1.0.0-beta.9/css/fonts.css");
 
 // Families
-$family-roboto-condensed: "Roboto Condensed", sans-serif;
-$family-source-sans-pro: "Source Sans Pro", sans-serif;
-$family-jetbrains-mono: "JetBrains Mono", monospace;
-$family-system: BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto",
-	"Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-	"Helvetica", "Arial", sans-serif;
+$family-roboto-condensed: 'Roboto Condensed', sans-serif;
+$family-source-sans-pro: 'Source Sans Pro', sans-serif;
+$family-jetbrains-mono: 'JetBrains Mono', monospace;
+$family-system: BlinkMacSystemFont, -apple-system, 'Segoe UI', 'Roboto',
+  'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+  'Helvetica', 'Arial', sans-serif;
 
 // Sizes
 $font-size-h1: 3.56rem;
@@ -27,39 +27,39 @@ $font-size-caption: 0.8rem;
 
 // Classes
 $body-font-sizes: (
-	"-bigger": $font-size-body-bigger,
-	"-big": $font-size-body-big,
-	"-normal": $font-size-body-normal,
-	"-list": $font-size-body-list,
+  "-bigger": $font-size-body-bigger,
+  "-big": $font-size-body-big,
+  "-normal": $font-size-body-normal,
+  "-list": $font-size-body-list,
 );
 
 @mixin body-typography($body-name, $body-font-size) {
-	.body#{$body-name} {
-		line-height: 1.6;
-		font-size: $body-font-size;
-	}
+  .body#{$body-name} {
+    line-height: 1.6;
+    font-size: $body-font-size;
+  }
 }
 
 @each $body-name, $body-font-size in $body-font-sizes {
-	@include body-typography($body-name, $body-font-size);
+  @include body-typography($body-name, $body-font-size);
 }
 
 .caption {
-	font-size: $font-size-caption;
+  font-size: $font-size-caption;
 }
 
 .value {
-	font-family: $family-roboto-condensed;
-	font-size: $font-size-value;
-	font-weight: bold;
+  font-family: $family-roboto-condensed;
+  font-size: $font-size-value;
+  font-weight: bold;
 
-	line-height: 1.3;
-	letter-spacing: 0.02em;
+  line-height: 1.3;
+  letter-spacing: 0.02em;
 }
 
 .monospace {
-	font-family: $family-monospace;
-	font-size: 0.875em; // Code fonts at 14px are similar to other fonts at 16px
+  font-family: $family-monospace;
+  font-size: 0.875em; // Code fonts at 14px are similar to other fonts at 16px
 }
 
 // Usage
@@ -69,46 +69,46 @@ h3,
 h4,
 h5,
 h6 {
-	color: $color-dark-slate-gray;
+  color: $color-dark-slate-gray;
 
-	font-family: $family-roboto-condensed;
-	font-weight: bold;
+  font-family: $family-roboto-condensed;
+  font-weight: bold;
 
-	text-transform: uppercase;
-	line-height: 1.3;
-	letter-spacing: 0.02rem;
+  text-transform: uppercase;
+  line-height: 1.3;
+  letter-spacing: 0.02rem;
 
-	&.b-header {
-		font-family: $family-source-sans-pro;
+  &.b-header {
+    font-family: $family-source-sans-pro;
 
-		text-transform: none;
-	}
+    text-transform: none;
+  }
 }
 
 $header-font-sizes: (
-	"h1": $font-size-h1,
-	"h2": $font-size-h2,
-	"h3": $font-size-h3,
-	"h4": $font-size-h4,
-	"h5": $font-size-h5,
-	"h6": $font-size-h6,
+  "h1": $font-size-h1,
+  "h2": $font-size-h2,
+  "h3": $font-size-h3,
+  "h4": $font-size-h4,
+  "h5": $font-size-h5,
+  "h6": $font-size-h6,
 );
 
 @mixin header-typography($header-name, $header-font-size) {
-	#{$header-name} {
-		font-size: $header-font-size;
-	}
+  #{$header-name} {
+    font-size: $header-font-size;
+  }
 }
 
 @each $header-name, $header-font-size in $header-font-sizes {
-	@include header-typography($header-name, $header-font-size);
+  @include header-typography($header-name, $header-font-size);
 }
 
 body {
-	font-family: $family-sans-serif;
-	font-size: $font-size-body-normal;
+  font-family: $family-sans-serif;
+  font-size: $font-size-body-normal;
 }
 
 a:hover {
-	text-decoration: underline;
+  text-decoration: underline;
 }

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -4,9 +4,15 @@
 $family-roboto-condensed: 'Roboto Condensed', sans-serif;
 $family-source-sans-pro: 'Source Sans Pro', sans-serif;
 $family-jetbrains-mono: 'JetBrains Mono', monospace;
+$family-vocabulary-icons: 'Vocabulary Icons';
 $family-system: BlinkMacSystemFont, -apple-system, 'Segoe UI', 'Roboto',
   'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
   'Helvetica', 'Arial', sans-serif;
+
+$family-heading: $family-roboto-condensed;
+$family-body: $family-source-sans-pro;
+$family-code: $family-jetbrains-mono;
+$family-icons: $family-vocabulary-icons;
 
 // Sizes
 $font-size-h1: 3.56rem;
@@ -49,7 +55,7 @@ $body-font-sizes: (
 }
 
 .value {
-  font-family: $family-roboto-condensed;
+  font-family: $family-heading;
   font-size: $font-size-value;
   font-weight: bold;
 
@@ -58,7 +64,7 @@ $body-font-sizes: (
 }
 
 .monospace {
-  font-family: $family-monospace;
+  font-family: $family-code;
   font-size: 0.875em; // Code fonts at 14px are similar to other fonts at 16px
 }
 
@@ -66,7 +72,7 @@ $body-font-sizes: (
 h1, h2, h3, h4, h5, h6 {
   color: $color-dark-slate-gray;
 
-  font-family: $family-roboto-condensed;
+  font-family: $family-heading;
   font-weight: bold;
 
   text-transform: uppercase;
@@ -74,7 +80,7 @@ h1, h2, h3, h4, h5, h6 {
   letter-spacing: 0.02rem;
 
   &.b-header {
-    font-family: $family-source-sans-pro;
+    font-family: $family-body;
 
     text-transform: none;
   }
@@ -100,7 +106,7 @@ $header-font-sizes: (
 }
 
 body {
-  font-family: $family-sans-serif;
+  font-family: $family-body;
   font-size: $font-size-body-normal;
 }
 

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -1,11 +1,12 @@
 @import url("https://unpkg.com/@creativecommons/fonts@1.0.0-beta.9/css/fonts.css");
 
 // Families
-$family-roboto-condensed: 'Roboto Condensed', sans-serif;
-$family-source-sans-pro: 'Source Sans Pro', sans-serif;
-$family-jetbrains-mono: 'JetBrains Mono', monospace;
-$family-system: BlinkMacSystemFont, -apple-system, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
-'Droid Sans', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+$family-roboto-condensed: "Roboto Condensed", sans-serif;
+$family-source-sans-pro: "Source Sans Pro", sans-serif;
+$family-jetbrains-mono: "JetBrains Mono", monospace;
+$family-system: BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto",
+	"Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+	"Helvetica", "Arial", sans-serif;
 
 // Sizes
 $font-size-h1: 3.56rem;
@@ -24,90 +25,90 @@ $font-size-body-list: 1rem;
 
 $font-size-caption: 0.8rem;
 
-// Overrides
-$family-sans-serif: $family-source-sans-pro;
-$family-alternative: $family-roboto-condensed;
-$family-monospace: $family-jetbrains-mono;
-
 // Classes
 $body-font-sizes: (
-  "-bigger": $font-size-body-bigger,
-  "-big": $font-size-body-big,
-  "-normal": $font-size-body-normal,
-  "-list": $font-size-body-list,
+	"-bigger": $font-size-body-bigger,
+	"-big": $font-size-body-big,
+	"-normal": $font-size-body-normal,
+	"-list": $font-size-body-list,
 );
 
 @mixin body-typography($body-name, $body-font-size) {
-  .body#{$body-name} {
-    line-height: 1.6;
-    font-size: $body-font-size;
-  }
+	.body#{$body-name} {
+		line-height: 1.6;
+		font-size: $body-font-size;
+	}
 }
 
 @each $body-name, $body-font-size in $body-font-sizes {
-  @include body-typography($body-name, $body-font-size);
+	@include body-typography($body-name, $body-font-size);
 }
 
 .caption {
-  font-size: $font-size-caption;
+	font-size: $font-size-caption;
 }
 
 .value {
-  font-family: $family-roboto-condensed;
-  font-size: $font-size-value;
-  font-weight: bold;
+	font-family: $family-roboto-condensed;
+	font-size: $font-size-value;
+	font-weight: bold;
 
-  line-height: 1.3;
-  letter-spacing: 0.02em;
+	line-height: 1.3;
+	letter-spacing: 0.02em;
 }
 
 .monospace {
-  font-family: $family-monospace;
-  font-size: 0.875em; // Code fonts at 14px are similar to other fonts at 16px
+	font-family: $family-monospace;
+	font-size: 0.875em; // Code fonts at 14px are similar to other fonts at 16px
 }
 
 // Usage
-h1, h2, h3, h4, h5, h6 {
-  color: $color-dark-slate-gray;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	color: $color-dark-slate-gray;
 
-  font-family: $family-roboto-condensed;
-  font-weight: bold;
+	font-family: $family-roboto-condensed;
+	font-weight: bold;
 
-  text-transform: uppercase;
-  line-height: 1.3;
-  letter-spacing: 0.02rem;
+	text-transform: uppercase;
+	line-height: 1.3;
+	letter-spacing: 0.02rem;
 
-  &.b-header {
-  font-family: $family-source-sans-pro;
+	&.b-header {
+		font-family: $family-source-sans-pro;
 
-  text-transform: none;
-  }
+		text-transform: none;
+	}
 }
 
 $header-font-sizes: (
-  "h1": $font-size-h1,
-  "h2": $font-size-h2,
-  "h3": $font-size-h3,
-  "h4": $font-size-h4,
-  "h5": $font-size-h5,
-  "h6": $font-size-h6,
+	"h1": $font-size-h1,
+	"h2": $font-size-h2,
+	"h3": $font-size-h3,
+	"h4": $font-size-h4,
+	"h5": $font-size-h5,
+	"h6": $font-size-h6,
 );
 
 @mixin header-typography($header-name, $header-font-size) {
-  #{$header-name} {
-    font-size: $header-font-size;
-  }
+	#{$header-name} {
+		font-size: $header-font-size;
+	}
 }
 
 @each $header-name, $header-font-size in $header-font-sizes {
-  @include header-typography($header-name, $header-font-size);
+	@include header-typography($header-name, $header-font-size);
 }
 
 body {
-  font-family: $family-sans-serif;
-  font-size: $font-size-body-normal;
+	font-family: $family-sans-serif;
+	font-size: $font-size-body-normal;
 }
 
-a:hover{
-  text-decoration: underline;
+a:hover {
+	text-decoration: underline;
 }

--- a/src/styles/typography_overrides.scss
+++ b/src/styles/typography_overrides.scss
@@ -1,8 +1,13 @@
-$family-sans-serif: $family-source-sans-pro;
-$family-alternative: $family-roboto-condensed;
-$family-monospace: $family-jetbrains-mono;
+$family-sans-serif: $family-body;
+$family-monospace: $family-code;
 
-$size-4: $font-size-body-bigger;
+$size-1: $font-size-h1;
+$size-2: $font-size-h2;
+$size-3: $font-size-h3;
+$size-4: $font-size-body-bigger; // Same as $font-size-h4
 $size-5: $font-size-body-big;
 $size-6: $font-size-body-normal;
 $size-7: $font-size-caption;
+
+$family-primary: $family-body;
+$family-secondary: $family-heading;

--- a/src/styles/typography_overrides.scss
+++ b/src/styles/typography_overrides.scss
@@ -1,0 +1,8 @@
+$family-sans-serif: $family-source-sans-pro;
+$family-alternative: $family-roboto-condensed;
+$family-monospace: $family-jetbrains-mono;
+
+$size-4: $font-size-body-bigger;
+$size-5: $font-size-body-big;
+$size-6: $font-size-body-normal;
+$size-7: $font-size-caption;

--- a/src/styles/vocabulary.scss
+++ b/src/styles/vocabulary.scss
@@ -12,7 +12,8 @@
 @import "./typography.scss";
 
 // Bulma overrides
-@import "./overrides.scss";
+@import "./color_overrides.scss";
+@import "./typography_overrides.scss";
 
 // Elements
 @import "./button.scss";

--- a/src/styles/vocabulary.scss
+++ b/src/styles/vocabulary.scss
@@ -2,6 +2,7 @@
 
 // Tokens
 @import "./color.scss";
+@import "./color_overrides.scss";
 
 // Bulma
 @import "bulma/sass/utilities/_all.sass";
@@ -9,10 +10,8 @@
 
 // More tokens
 @import "./spacing.scss";
-@import "./typography.scss";
 
-// Bulma overrides
-@import "./color_overrides.scss";
+@import "./typography.scss";
 @import "./typography_overrides.scss";
 
 // Elements

--- a/src/styles/vocabulary.scss
+++ b/src/styles/vocabulary.scss
@@ -11,6 +11,9 @@
 @import "./spacing.scss";
 @import "./typography.scss";
 
+// Bulma overrides
+@import "./overrides.scss";
+
 // Elements
 @import "./button.scss";
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Related to #425 by @dhruvkb 

## Description
This overrides the default Bulma variables with the Vocabulary's token values

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
