### PR TITLE
Fix showed source code of input element story

### DIFF
--- a/src/stories/input.stories.mdx
+++ b/src/stories/input.stories.mdx
@@ -15,24 +15,24 @@ export const inputType = (size) => {
 <input class="input${sizeClass}" type="text" value="Fixed text" disabled/>`
 }
 
-<Preview mdxSource={inputType('input')}>
-  <Story name="Normal" parameters={{
+<Preview mdxSource={inputType('')}>
+  <Story name="Normal" height="200px" parameters={{
     design: figmaConfig('1%3A24')
   }}>{
     inputType('')
   }</Story>
 </Preview>
 
-<Preview mdxSource={inputType('input is-medium')}>
-  <Story name="Medium" parameters={{
+<Preview mdxSource={inputType('medium')}>
+  <Story name="Medium" height="250px" parameters={{
     design: figmaConfig('1%3A24')
   }}>{`
     ${inputType('medium')}
   `}</Story>
 </Preview>
 
-<Preview mdxSource={inputType('input is-large')}>
-  <Story name="Large" parameters={{
+<Preview mdxSource={inputType('large')}>
+  <Story name="Large" height="320px" parameters={{
     design: figmaConfig('1%3A24')
   }}>{`
     ${inputType('large')}

--- a/src/stories/input.stories.mdx
+++ b/src/stories/input.stories.mdx
@@ -26,15 +26,15 @@ export const inputType = (size) => {
 <Preview mdxSource={inputType('medium')}>
   <Story name="Medium" height="250px" parameters={{
     design: figmaConfig('1%3A24')
-  }}>{`
-    ${inputType('medium')}
-  `}</Story>
+  }}>{
+    inputType('medium')
+  }</Story>
 </Preview>
 
 <Preview mdxSource={inputType('large')}>
   <Story name="Large" height="320px" parameters={{
     design: figmaConfig('1%3A24')
-  }}>{`
-    ${inputType('large')}
-  `}</Story>
+  }}>{
+    inputType('large')
+  }</Story>
 </Preview>

--- a/src/stories/select.stories.mdx
+++ b/src/stories/select.stories.mdx
@@ -31,7 +31,7 @@ export const selectDiv = () => `
 </div>`
 
 <Preview mdxSource={selectDiv()}>
-  <Story name="Default" height="190px" parameters={{
+  <Story name="Default" height="200px" parameters={{
     design: figmaConfig('603%3A6')
   }}>{
     selectDiv()

--- a/src/stories/select.stories.mdx
+++ b/src/stories/select.stories.mdx
@@ -5,32 +5,35 @@ import { figmaConfig } from './helpers'
 
 # Select
 
-<Preview>
-  <Story name="Default" parameters={{
+export const selectDiv = () => `
+<div class="select">
+  <select>
+    <option disabled selected>Select</option>
+    <option>Option A</option>
+    <option>Option B</option>
+  </select>
+</div>
+<br/><br/>
+<div class="select">
+  <select>
+    <option disabled>Select</option>
+    <option>Option A</option>
+    <option>Option B</option>
+  </select>
+</div>
+<br/><br/>
+<div class="select">
+  <select disabled>
+    <option disabled>Select</option>
+    <option>Option A</option>
+    <option>Option B</option>
+  </select>
+</div>`
+
+<Preview mdxSource={selectDiv()}>
+  <Story name="Default" height="190px" parameters={{
     design: figmaConfig('603%3A6')
-  }}>{`
-    <div class="select">
-      <select>
-        <option disabled selected>Select</option>
-        <option>Option A</option>
-        <option>Option B</option>
-      </select>
-    </div>
-    <br/><br/>
-    <div class="select">
-      <select>
-        <option disabled>Select</option>
-        <option>Option A</option>
-        <option>Option B</option>
-      </select>
-    </div>
-    <br/><br/>
-    <div class="select">
-      <select disabled>
-        <option disabled>Select</option>
-        <option>Option A</option>
-        <option>Option B</option>
-      </select>
-    </div>
-  `}</Story>
+  }}>{
+    selectDiv()
+  }</Story>
 </Preview>


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #467 by @krysal 

## Description
Remove `is-input` class of Input story. Also change the way the Select story is built to enable syntax highlight on code section.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
