### PR TITLE
Add docs for Global Header and JS in general

### DIFF
--- a/.storybook/meta/usage.stories.mdx
+++ b/.storybook/meta/usage.stories.mdx
@@ -34,6 +34,10 @@ Alternatively, you can import the SCSS styleheets into your own stylesheets.
 @import '~@creativecommons/vocabulary/scss/footer.scss'
 ```
 
+### JavaScript
+
+Coming soon.
+
 ### Assets
 
 You can reference assets using file loader or SVG inline loader.
@@ -75,10 +79,42 @@ Just link to the master CSS file with any of these one-line `link` tags within y
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@creativecommons/vocabulary/css/vocabulary.css">
 ```
 
+### JavaScript
+
+Source the bundled JS file with any of these one-link `script` tags within your document `head` tag.
+
+#### unpkg
+
+```html
+<!-- If you have a specific version in mind, use -->
+<script src="https://unpkg.com/@creativecommons/vocabulary@1.0.0-beta.6/js/vocabulary.js">
+<!-- or, if you prefer the latest version, use -->
+<script src="https://unpkg.com/@creativecommons/vocabulary/js/vocabulary.js">
+```
+
+#### jsDelivr
+
+```html
+<!-- If you have a specific version in mind, use -->
+<script src="https://cdn.jsdelivr.net/npm/@creativecommons/vocabulary@1.0.0-beta.6/js/vocabulary.js">
+<!-- or, if you prefer the latest version, use -->
+<script src="https://cdn.jsdelivr.net/npm/@creativecommons/vocabulary/js/vocabulary.js">
+```
+
+#### Post-sourcing
+
+The JavaScript bundle is imported as `vocabulary` in the global scope. You can then access the functions as follows.
+
+```html
+<script>
+  vocabulary.createGlobalHeader()
+</script>
+```
+
 ### Assets
 
 Vocabulary bundles a number of assets, like SVGs for the brand and product logos, and license badges. Since SVGs cannot
-directly be hotlinked from the CDNs due to cross-origin issues, you'll need to adopt this workaround.
+directly be hotlinked from the CDNs due to cross-origin issues, you will need to adopt this workaround.
 
 ```html
 <script>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -17,6 +17,14 @@
     background-color: #f5f5f5;
   }
 
+  .sbdocs.sbdocs-preview.tight > div > div {
+    padding: 0;
+  }
+
+  .sbdocs.sbdocs-preview.tight > div > div > div {
+    margin-top: 0;
+  }
+
   .sbdocs.sbdocs-pre .docblock-source {
     margin-top: 0;
     margin-bottom: 0;

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
-import './scripts/vocabulary' // JavaScript scripts, will be bundled
 import './styles/vocabulary.scss' // Sass stylesheets, will be compiled
+export * from './scripts/vocabulary' // JavaScript scripts, will be bundled

--- a/src/scripts/constants.js
+++ b/src/scripts/constants.js
@@ -2,7 +2,7 @@ export const CC_ORG_URL = 'https://creativecommons.org'
 export const DONATION_URL = 'https://us.netdonor.net/page/6650/donate/1?ea.tracking.id=global-navigation-bar'
 
 export const CDN_BASE_URL = 'https://unpkg.com/@creativecommons/vocabulary'
-export const GLOBAL_HEADER_API_URL = 'https://creativecommons.org/wp-json/ccglobal/menu'
+export const GLOBAL_HEADER_API_URL = 'https://cors-anywhere.herokuapp.com/https://creativecommons.org/wp-json/ccglobal/menu'
 
 // TODO: Internationalise
 export const DONATION_TITLE = 'Our work relies on you!'

--- a/src/scripts/constants.js
+++ b/src/scripts/constants.js
@@ -2,7 +2,7 @@ export const CC_ORG_URL = 'https://creativecommons.org'
 export const DONATION_URL = 'https://us.netdonor.net/page/6650/donate/1?ea.tracking.id=global-navigation-bar'
 
 export const CDN_BASE_URL = 'https://unpkg.com/@creativecommons/vocabulary'
-export const GLOBAL_HEADER_API_URL = 'https://cors-anywhere.herokuapp.com/https://creativecommons.org/wp-json/ccglobal/menu'
+export const GLOBAL_HEADER_API_URL = 'https://creativecommons.org/wp-json/ccglobal/menu'
 
 // TODO: Internationalise
 export const DONATION_TITLE = 'Our work relies on you!'

--- a/src/scripts/global_header.js
+++ b/src/scripts/global_header.js
@@ -27,6 +27,7 @@ class GlobalHeader {
         viewBox="0 0 304 73">
         <use href="#logomark"></use>
       </svg>`
+    this.element = null
   }
 
   queryApi (callbackFn) {
@@ -129,6 +130,7 @@ class GlobalHeader {
     })
 
     document.body.prepend(mainContainer)
+    this.element = mainContainer
   }
 
   up () {
@@ -139,4 +141,5 @@ class GlobalHeader {
 export function createGlobalHeader () {
   const globalHeader = new GlobalHeader()
   globalHeader.up()
+  return globalHeader
 }

--- a/src/scripts/vocabulary.js
+++ b/src/scripts/vocabulary.js
@@ -1,3 +1,1 @@
-import { createGlobalHeader } from './global_header'
-
-createGlobalHeader()
+export { createGlobalHeader } from './global_header'

--- a/src/stories/github_corner.stories.mdx
+++ b/src/stories/github_corner.stories.mdx
@@ -17,8 +17,8 @@ export const isNormal = `<a class="github-corner">
   ${GitHubCorner}
 </a>`
 
-<Preview mdxSource={isNormal}>
-  <Story name="Normal" height="100px" parameters={{
+<Preview mdxSource={isNormal} className="tight">
+  <Story name="Normal" height="120px" parameters={{
     design: figmaConfig('795%3A1')
   }}>{
     isNormal.toString()
@@ -31,8 +31,8 @@ export const isInverted = `<a class="github-corner is-inverted">
   ${GitHubCorner}
 </a>`
 
-<Preview mdxSource={isInverted} style={{backgroundColor: 'black'}}>
-  <Story name="Inverted" height="100px" parameters={{
+<Preview mdxSource={isInverted} style={{backgroundColor: 'black'}} className="tight">
+  <Story name="Inverted" height="120px" parameters={{
     backgrounds: [
       { name: 'black', value: 'black', default: true }
     ],
@@ -48,8 +48,8 @@ export const isLeftAligned = `<a class="github-corner is-left-aligned">
   ${GitHubCorner}
 </a>`
 
-<Preview mdxSource={isLeftAligned}>
-  <Story name="Left aligned" height="100px" parameters={{
+<Preview mdxSource={isLeftAligned} className="tight">
+  <Story name="Left aligned" height="120px" parameters={{
     design: figmaConfig('795%3A1')
   }}>{
     isLeftAligned.toString()

--- a/src/stories/global_header.stories.mdx
+++ b/src/stories/global_header.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Preview, Story } from '@storybook/addon-docs/blocks'
-import { svgCode } from './helpers'
+import { createGlobalHeader } from '../scripts/global_header'
 
 <Meta
   title="Patterns/Global header"
@@ -9,81 +9,11 @@ import { svgCode } from './helpers'
    ]
 }}/>
 
-export const header = (state) => `
-<header class="cc-global-header ${state}">
-  <div class="container">
-    <a href="#" class="open-tab">Explore CC</a>
-    <div class="global-header-content">
-      <div class="level">
-        <div class="level-left">
-          <header class="global-header-header">
-            <a href="https://creativecommons.org" target="_blank" class="main-logo">
-              <div class="has-text-white">${svgCode(304, 73, 'cc/logomark', 'logomark')}</div>
-            </a>
-          </header>
-        </div>
-      </div>
-      <div class="columns padding-bottom-normal">
-        <div class="column is-one-third">
-          <aside class="donate-section">
-            <h5>Our work relies on you!</h5>
-            <p>Help us keep the internet free and open.</p>
-            <a class="button small donate">
-              <i class="icon cc-letterheart margin-right-small is-size-5 padding-top-smaller"></i> Donate now
-            </a>
-          </aside>
-        </div>
-        <div class="column">
-          <nav class="products" role="navigation" aria-label="global navigation">
-            <div class="product-list">
-              <a href="https://network.creativecommons.org" target="_blank" class="product-item">
-                <strong>Global Network</strong>
-                <span class="item-description">
-                  Join a global community working wo strenghten the Commons
-                </span>
-              </a>
-              <a href="https://certificate.creativecommons.org" target="_blank" class="product-item">
-                <strong>Certificate Program</strong>
-                <span class="item-description">
-                  Become an expert in creating and engaging with openly licensed materials
-                </span>
-              </a>
-              <a href="https://summit.creativecommons.org" target="_blank" class="product-item">
-                <strong>Global Summit</strong>
-                <span class="item-description">
-                  Attend oir annual event, promoting the power of open licensing
-                </span>
-              </a>
-              <a href="https://chooser-beta.creativecommons.org" target="_blank" class="product-item">
-                <strong>License Chooser</strong>
-                <span class="item-description">
-                  Get help choosing the appropiate license for your work
-                </span>
-              </a>
-              <a href="https://search.creativecommons.org" target="_blank" class="product-item">
-                <strong>CC Search</strong>
-                <span class="item-description">
-                  Find openly licensed material for creative and educational reuse
-                </span>
-              </a>
-              <a href="https://opensource.creativecommons.org" target="_blank" class="product-item">
-                <strong>CC Open Source</strong>
-                <span class="item-description">
-                  Help us build products that maximize creativity and innovation
-                </span>
-              </a>
-            </div>
-          </nav>
-        </div>
-      </div>
-    </div>
-  </div>
-</header>`
+export const globalHeader = 'vocabulary.createGlobalHeader()'
 
-<Preview mdxSource={header()}>
-  <Story name="Inactive">{header()}</Story>
-</Preview>
-
-<Preview mdxSource={header('is-active')}>
-  <Story name="Active">{header('is-active')}</Story>
+<Preview mdxSource={globalHeader} className="tight">
+  <Story name="Interactive">{() => {
+    createGlobalHeader()
+    return ''
+  }}</Story>
 </Preview>

--- a/src/stories/global_header.stories.mdx
+++ b/src/stories/global_header.stories.mdx
@@ -1,3 +1,4 @@
+import { useEffect } from '@storybook/client-api'
 import { Meta, Preview, Story } from '@storybook/addon-docs/blocks'
 import { createGlobalHeader } from '../scripts/global_header'
 
@@ -9,11 +10,21 @@ import { createGlobalHeader } from '../scripts/global_header'
    ]
 }}/>
 
-export const globalHeader = 'vocabulary.createGlobalHeader()'
+export const globalHeader = 'const globalHeaderInstance = vocabulary.createGlobalHeader()'
 
 <Preview mdxSource={globalHeader} className="tight">
   <Story name="Interactive">{() => {
-    createGlobalHeader()
-    return ''
+    // Using Storybook hooks to clean up effects of DOM insertion
+    useEffect(() => {
+      // Function body executes for componentDidMount
+      const globalHeaderInstance = createGlobalHeader()
+      // Return function executes for componentWillUnmount
+      return () => {
+        if (globalHeaderInstance && globalHeaderInstance.element) {
+          globalHeaderInstance.element.remove()
+        }
+      }
+    })
+    return '<div style="background-color: rgb(237, 89, 47); height: 200px;"></div>'
   }}</Story>
 </Preview>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,8 @@ module.exports = {
   entry: './src/index.js',
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: 'js/vocabulary.js'
+    filename: 'js/vocabulary.js',
+    library: 'vocabulary'
   },
   module: {
     rules: [{


### PR DESCRIPTION
## Description
Vocabulary now has a JS module too. This PR documents how to source it and use it.

## Technical details
Documentation on how to use it via `npm` is missing, mainly because I haven't used it via `npm` yet. @Dhruvi16 might be able to add it since she's using the library in CC-OS.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
