### PR TITLE
Move Designs from addons panel to its own tab

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,7 +4,12 @@ module.exports = {
     '../src/stories/*.stories.mdx'
   ],
   addons: [
-    'storybook-addon-designs',
+    {
+      name: 'storybook-addon-designs',
+      options: {
+        renderTarget: 'tab'
+      }
+    },
     '@storybook/addon-knobs',
     '@storybook/addon-backgrounds',
     '@storybook/addon-viewport',

--- a/src/stories/color.stories.mdx
+++ b/src/stories/color.stories.mdx
@@ -149,5 +149,5 @@ For each of the brand colors, we have two helper classes:
   design: figmaConfig('0%3A72'),
   docs: { disable: true }
 }}>{`
-  See the Design tab in the panel.
+  See the Design tab.
 `}</Story>

--- a/src/stories/icons.stories.mdx
+++ b/src/stories/icons.stories.mdx
@@ -30,5 +30,5 @@ body.sb-show-main,
   design: figmaConfig('0%3A135'),
   docs: { disable: true }
 }}>{`
-  See the Design tab in the panel.
+  See the Design tab.
 `}</Story>

--- a/src/stories/spacing.stories.mdx
+++ b/src/stories/spacing.stories.mdx
@@ -58,5 +58,5 @@ size and each property we have two kinds of helper classes:
   design: figmaConfig('0%3A190'),
   docs: { disable: true }
 }}>{`
-  See the Design tab in the panel.
+  See the Design tab.
 `}</Story>

--- a/src/stories/typography.stories.mdx
+++ b/src/stories/typography.stories.mdx
@@ -102,5 +102,5 @@ Code can be rendered with the class `.monospace` on the `<p>` tag.
   design: figmaConfig('0%3A110'),
   docs: { disable: true }
 }}>{`
-  See the Design tab in the panel.
+  See the Design tab.
 `}</Story>


### PR DESCRIPTION
## Description
With Dependabot's PR #488 `storybook-addon-designs` was updated to version 5.3.0 that adds support for the addon to be configured as a tab. This PR does just that.

## Technical details
The documentation for the addon does not mention the process so replicating this in other repositories might require this PR to be referenced for the right implementation.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
