### PR TITLE
Fix homepage link

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "webpack-cli": "^3.3.10"
   },
   "bugs": "https://github.com/creativecommons/vocabulary/issues/",
-  "homepage": "https://creativecommons.github.io/vocabulary/",
+  "homepage": "https://opensource.creativecommons.org/vocabulary",
   "keywords": [
     "ui",
     "ux",


### PR DESCRIPTION
Updates the broken homepage link in `package.json` to fix our public homepage link on npm. Will be fixed the next time we release.

~Note: Is technically blocked by the next deployment of https://opensource.creativecommons.org (I don't know what the deployment process there is.)~ Okay, that's fast. Nice! 😆 

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
