### PR TITLE
Release v2020.08.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@creativecommons/vocabulary",
-  "version": "2020.07.4",
+  "version": "2020.08.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creativecommons/vocabulary",
-  "version": "2020.07.4",
+  "version": "2020.08.1",
   "description": "A cohesive design system to unite the web facing Creative Commons",
   "author": "Creative Commons (https://creativecommons.org)",
   "scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = {
         {
           loader: 'sass-loader',
           options: {
-            sourceMap: true,
+            sourceMap: true
           }
         }
       ]
@@ -30,9 +30,11 @@ module.exports = {
     new MiniCssExtractPlugin({
       filename: 'css/vocabulary.css'
     }),
-    new CopyPlugin([
-      { from: 'src/styles', to: 'scss' },
-      { from: 'src/assets', to: 'assets' }
-    ]),
+    new CopyPlugin({
+      patterns: [
+        { from: 'src/styles', to: 'scss' },
+        { from: 'src/assets', to: 'assets' }
+      ]
+    })
   ]
 }


### PR DESCRIPTION
Release PR for [v2020.08.1](https://github.com/creativecommons/vocabulary/releases/tag/v2020.08.1)
Also includes a small config hotfix for `copy-webpack-plugin`, fixing a bug introduced by a Dependabot merge.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
