### PR TITLE
Fix tagging for v2020.08.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@creativecommons/vocabulary",
-  "version": "2020.08.2",
+  "version": "2020.08.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creativecommons/vocabulary",
-  "version": "2020.08.2",
+  "version": "2020.08.3",
   "description": "A cohesive design system to unite the web facing Creative Commons",
   "author": "Creative Commons (https://creativecommons.org)",
   "scripts": {


### PR DESCRIPTION
Fixes last release, which seemed to fail to due a misapplied tag.