### PR TITLE
change `a` tag in compact notification to `span`

### DIFF
--- a/src/stories/notification.stories.mdx
+++ b/src/stories/notification.stories.mdx
@@ -38,9 +38,9 @@ import { figmaConfig } from './helpers'
 <Preview>
   <Story name="Compact Notification">{`
     <div class="notification is-compact">
-      <a href="#" class="notification-container has-background-success-light">
+      <span class="notification-container has-background-success-light">
         <p>This is a title of a message</p>
-      </a>
+      </span>
     </div>
   `}</Story>
 </Preview>


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->

The reason behind this change is that the user is not expected to interact or click on the notification. This component will only be used to show a message.

You can refer to the discussion in #569.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

*Before*
![link](https://user-images.githubusercontent.com/34679965/89893633-556f0b80-dbf6-11ea-8e10-870162f9364b.gif)

*After*
![span](https://user-images.githubusercontent.com/34679965/89893638-56a03880-dbf6-11ea-93c4-34b487e4ed84.gif)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
