### PR TITLE
Fix subtitle size modifiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@creativecommons/vocabulary",
-  "version": "2020.8.5",
+  "version": "2020.8.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/stories/typography.stories.mdx
+++ b/src/stories/typography.stories.mdx
@@ -28,9 +28,11 @@ export const title = () => `
 `
 
 export const subtitle = () => `
-<h3 class="subtitle is-3">Heading B</h3>
-<h4 class="subtitle is-4">Heading B</h4>
-<h5 class="subtitle is-5">Heading B</h5>
+<p class="subtitle is-1">Subtitle 1</p>
+<p class="subtitle is-2">Subtitle 2</p>
+<p class="subtitle is-3">Subtitle 3</p>
+<p class="subtitle is-4">Subtitle 4</p>
+<p class="subtitle is-5">Subtitle 5</p>
 `
 
 Headings of type A need no additional classes to be used. They directly apply to all heading tags from `<h1>` to `<h5>`.

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -102,7 +102,9 @@ $header-font-sizes: (
 );
 
 @mixin header-typography($header-level, $header-font-size) {
-  h#{$header-level}, .title.is-#{$header-level} {
+  h#{$header-level},
+  .title.is-#{$header-level},
+  .subtitle.is-#{$header-level} {
     font-size: $header-font-size;
   }
 }

--- a/tests/unit/typography.scss
+++ b/tests/unit/typography.scss
@@ -6,7 +6,7 @@
       }
 
       @include expect {
-        h1, .title.is-1 {
+        h1, .title.is-1, .subtitle.is-1 {
           font-size: 3.56rem;
         }
       }


### PR DESCRIPTION
For the new `subtitle` class (extended from bulma) the modifier classes to change font size (`is-x`) weren't actually working. This PR fixes that.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
