### PR TITLE
currentColor for link colors

### DIFF
--- a/src/styles/color_overrides.scss
+++ b/src/styles/color_overrides.scss
@@ -32,5 +32,5 @@ $danger-dark: $color-dark-error;
 $danger-light: $color-light-error;
 
 $link: $color-tomato;
-$link-hover: $color-tomato;
-$link-visited: $color-tomato;
+$link-hover: currentColor;
+$link-visited: currentColor;


### PR DESCRIPTION
Previously I fixed link colors to be orange. I think a _more accurate and helpful_ default is for visited and hovered links to be set to `currentColor`, so they always reflect the original link color. That better suits the Design Library.
 
[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
