### PR TITLE
Release v2020.9.1

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.0"
+  "version": "2020.8.7"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2020.8.7"
+  "version": "2020.9.1"
 }

--- a/packages/fonts/package-lock.json
+++ b/packages/fonts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@creativecommons/fonts",
-  "version": "2020.8.1",
+  "version": "2020.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creativecommons/fonts",
-  "version": "2020.8.1",
+  "version": "2020.9.1",
   "description": "Typefaces that lend personality to the web facing Creative Commons",
   "author": "Creative Commons (https://creativecommons.org)",
   "scripts": {

--- a/packages/vocabulary/package-lock.json
+++ b/packages/vocabulary/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@creativecommons/vocabulary",
-  "version": "2020.8.7",
+  "version": "2020.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/vocabulary/package.json
+++ b/packages/vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creativecommons/vocabulary",
-  "version": "2020.8.7",
+  "version": "2020.9.1",
   "description": "A cohesive design system to unite the web facing Creative Commons",
   "author": "Creative Commons (https://creativecommons.org)",
   "scripts": {

--- a/packages/vue-vocabulary/package-lock.json
+++ b/packages/vue-vocabulary/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@creativecommons/vue-vocabulary",
-  "version": "1.0.0-beta.10",
+  "version": "2020.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/vue-vocabulary/package.json
+++ b/packages/vue-vocabulary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creativecommons/vue-vocabulary",
-  "version": "1.0.0-beta.10",
+  "version": "2020.9.1",
   "description": "Vue components implementing a cohesive design system to unite the web facing Creative Commons",
   "author": "Creative Commons (https://creativecommons.org)",
   "scripts": {
@@ -13,7 +13,7 @@
     "build:documentation": "npm run build && vue-cli-service storybook:build -s ./src/assets -o ./docs"
   },
   "dependencies": {
-    "@creativecommons/vocabulary": "^2020.8.7",
+    "@creativecommons/vocabulary": "^2020.9.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.30",
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-regular-svg-icons": "^5.14.0",


### PR DESCRIPTION
Updated all package versions with `npx lerna version 2020.9.1`. 

The `netlify/cc-vue-vocabulary/deploy-preview` check is expected to fail, as it relies on the latest version of vocabulary v2020.9.1, which won't be live until this PR is merged!

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
