### PR TITLE
Vocabulary migration

### DIFF
--- a/packages/vocabulary/.storybook/main.js
+++ b/packages/vocabulary/.storybook/main.js
@@ -1,7 +1,7 @@
 module.exports = {
   stories: [
-    './meta/*.stories.mdx',
-    '../src/stories/*.stories.mdx'
+    './meta/*.stories.*',
+    '../src/stories/*.stories.*'
   ],
   addons: [
     {
@@ -10,9 +10,6 @@ module.exports = {
         renderTarget: 'tab'
       }
     },
-    '@storybook/addon-knobs',
-    '@storybook/addon-backgrounds',
-    '@storybook/addon-viewport',
-    '@storybook/addon-docs'
+    '@storybook/addon-essentials',
   ]
 }

--- a/packages/vocabulary/.storybook/preview.js
+++ b/packages/vocabulary/.storybook/preview.js
@@ -1,7 +1,6 @@
 import { addDecorator, addParameters, } from '@storybook/html'
 
 import { withDesign } from 'storybook-addon-designs'
-import { withKnobs } from '@storybook/addon-knobs'
 
 import viewports from './viewport'
 import order from './order'
@@ -10,18 +9,19 @@ import '../dist/css/vocabulary.css'
 
 addParameters({
   options: {
-    showRoots: true,
     storySort: order
   },
-  backgrounds: [
+  backgrounds: {
+    default: 'canvas',
+    values: [
     { name: 'canvas', value: '#f5f5f5', default: true },
     { name: 'white', value: '#ffffff' },
     { name: 'black', value: '#000000' }
-  ],
+    ]
+  },
   viewport: {
     viewports
   }
 })
 
 addDecorator(withDesign)
-addDecorator(withKnobs)

--- a/packages/vocabulary/package.json
+++ b/packages/vocabulary/package.json
@@ -16,11 +16,8 @@
   "devDependencies": {
     "@babel/core": "^7.8.3",
     "@babel/preset-env": "^7.9.0",
-    "@storybook/addon-backgrounds": "^5.3.21",
-    "@storybook/addon-docs": "^6.0.4",
-    "@storybook/addon-knobs": "^6.0.4",
-    "@storybook/addon-viewport": "^6.0.4",
-    "@storybook/html": "^6.0.4",
+    "@storybook/addon-essentials": "^6.0.21",
+    "@storybook/html": "^6.0.21",
     "babel-jest": "^26.1.0",
     "babel-loader": "^8.0.6",
     "bulma": "^0.9.0",
@@ -46,7 +43,7 @@
     "sass-loader": "^9.0.2",
     "sass-true": "^5.0.0",
     "start-server-and-test": "^1.10.11",
-    "storybook-addon-designs": "^5.4.1",
+    "storybook-addon-designs": "^5.4.2",
     "style-loader": "^1.1.3",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10"

--- a/packages/vocabulary/src/stories/buttons.stories.mdx
+++ b/packages/vocabulary/src/stories/buttons.stories.mdx
@@ -1,13 +1,13 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas} from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
-<Meta title="Elements/Buttons" argTypes={{ label: { control: 'text' } } }/>
+<Meta title="Elements/Buttons"/>
 
 # Buttons
 
 export const buttonClass = (classes, label, el = 'button', href='') => {
   classes = classes ? `${classes}` : ''
- return `<${el} ${href ? `href=${href}` : ''} class="button${classes}">${label}</${el}>`
+  return `<${el} ${href ? `href=${href}` : ''} class="button ${classes}">${label}</${el}>`
 }
 
 export const buttonDonateClass = (classes, label, el = 'button', href='') => {
@@ -17,143 +17,136 @@ export const buttonDonateClass = (classes, label, el = 'button', href='') => {
  ${label}</${el}>`
 }
 
-export const Template = (args) => buttonClass('',args.label)
-export const Template1 = (args) => buttonDonateClass('big',args.label)
-
 Buttons are created by adding the `.button` class to a `<button>`.
 
-<Preview mdxSource={buttonClass('','BUTTON')}>
+<Canvas>
   <Story name="MediumButton" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}
   args={{label: 'BUTTON'}}
-  >{
-  Template.bind({})
-  }
+  >
+  {args => buttonClass('',args.label)}
   </Story>
-</Preview>
+</Canvas>
 
 You can customize the size of buttons with the `.big`, `.small` and `.tiny` classes.
 
-<Preview mdxSource={buttonClass('big','BUTTON')}>
+<Canvas>
   <Story name="BigButton" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}
   args={{label: 'BUTTON'}}
   >
-  {
-    Template.bind({})
-  }</Story>
-</Preview>
+  {args => buttonClass('big',args.label)}
+  </Story>
+</Canvas>
 
-<Preview mdxSource={buttonClass('small','BUTTON')}>
+<Canvas>
   <Story name="SmallButton" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}
   args={{label: 'BUTTON'}}
-  >{
-    Template.bind({})
-  }</Story>
-</Preview>
+  >{args => buttonClass('small',args.label)}</Story>
+</Canvas>
 
-<Preview mdxSource={buttonClass('tiny','BUTTON')}>
+<Canvas>
   <Story name="TinyButton" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}
   args={{label: 'BUTTON'}}
-  >{
-    Template.bind({})
-  }</Story>
-</Preview>
+  >{args => buttonClass('tiny',args.label)}
+  </Story>
+</Canvas>
 
 You can also combine other classes such as `.is-primary` and `.donate` with the aforementioned size classes.
 
-<Preview mdxSource={buttonClass('is-primary big','BUTTON')}>
+<Canvas>
   <Story name="ButtonPrimary" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}
   args={{label: 'BUTTON'}}
   >
-  {
-    Template.bind({})
-  }</Story>
-</Preview>
+  {args => buttonClass('is-primary big',args.label)}
+  </Story>
+</Canvas>
 
-<Preview mdxSource={buttonDonateClass('big')}>
+<Canvas>
   <Story name="ButtonDonateLarge" height="100px" parameters={{
     design: figmaConfig('1404%3A19')
   }}
   args={{label: 'BUTTON'}}
-  >{
-    Template1.bind({})
-  }</Story>
-</Preview>
+  >{args => buttonDonateClass('big',args.label)}
+  </Story>
+</Canvas>
 
-<Preview mdxSource={buttonDonateClass('medium')}>
+<Canvas>
   <Story name="ButtonDonateMedium" height="100px" parameters={{
     design: figmaConfig('1404%3A19')
   }}
   args={{label: 'BUTTON'}}
-  >{
-    Template1.bind({})
-  }</Story>
-</Preview>
+  >{args => buttonDonateClass('medium',args.label)}
+  </Story>
+</Canvas>
 
-<Preview mdxSource={buttonDonateClass('small')}>
+<Canvas>
   <Story name="ButtonDonateNormal" height="100px" parameters={{
     design: figmaConfig('1404%3A19')
   }}
   args={{label: 'BUTTON'}}
-  >{
-    Template1.bind({})
-  }</Story>
-</Preview>
+  >{args => buttonDonateClass('small',args.label)}
+  </Story>
+</Canvas>
 
 Buttons may have four feedback colors such as `.is-success`, `.is-info`, `.is-warning` and `.is-danger`.
 
-<Preview mdxSource={buttonClass('is-success')}>
+<Canvas>
   <Story name="ButtonSuccess" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
-  }}>{
-    buttonClass('is-success')
-  }</Story>
-</Preview>
+  }}
+  args={{label:'BUTTON'}}
+  >{args => buttonClass('is-success',args.label)}
+  </Story>
+</Canvas>
 
-<Preview mdxSource={buttonClass('is-info')}>
+<Canvas>
   <Story name="ButtonInfo" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
-  }}>{
-    buttonClass('is-info')
-  }</Story>
-</Preview>
+  }}
+  args={{label:'BUTTON'}}
+  >{args => buttonClass('is-info',args.label)}
+  </Story>
+</Canvas>
 
-<Preview mdxSource={buttonClass('is-warning')}>
+<Canvas>
   <Story name="ButtonWarning" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
-  }}>{
-    buttonClass('is-warning')
-  }</Story>
-</Preview>
+  }}
+  args={{label:'BUTTON'}}
+  >{args => buttonClass('is-warning',args.label)}
+  </Story>
+</Canvas>
 
-<Preview mdxSource={buttonClass('is-danger')}>
+<Canvas>
   <Story name="ButtonError" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
-  }}>{
-    buttonClass('is-danger')
-  }</Story>
-</Preview>
+  }}
+  args={{label:'BUTTON'}}
+  >{args => buttonClass('is-danger',args.label)}
+  </Story>
+</Canvas>
 
 The `.tag` class is used to render a tag name.
 
-<Preview mdxSource={buttonClass('tag')}>
+<Canvas>
   <Story name="Tag" height="100px" parameters={{
     design: figmaConfig('1404%3A1')
-  }}>{
-    buttonClass('tag')
-  }</Story>
-</Preview>
+  }}
+  args={{label:'BUTTON'}}
+  >{args => buttonClass('tag','BUTTON')}
+  </Story>
+</Canvas>
 
-<Preview>
+<Canvas>
   <Story name="Removable Tag" height="100px" parameters={{
     design: figmaConfig('1404%3A1')
   }}>{`
@@ -162,24 +155,27 @@ The `.tag` class is used to render a tag name.
       <i class="icon cross"></i>
     </button>
   `}</Story>
-</Preview>
+</Canvas>
 
 You can use the `.is-text` to have a button looking more like a link, with no borders and background color.
 
-<Preview mdxSource={buttonClass('is-text')}>
+<Canvas>
   <Story name="Text" height="100px" parameters={{
     design: figmaConfig('1404%3A1')
-  }}>{
-    buttonClass('is-text')
-  }</Story>
-</Preview>
+  }}
+  args={{label:'BUTTON'}}
+  >
+  {args => buttonClass('is-text',args.label)}
+  </Story>
+</Canvas>
 
 Button styles should be applied to anchor tags (`<a>`) when using links. Avoid using JavaScript and `<button>` tags to replicate anchor tag behavior whenever possible.
 
-<Preview mdxSource={buttonClass('small', 'a', 'https://creativecommons.org')}>
+<Canvas>
   <Story name="Anchor Tags" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
-  }}>{
-    buttonClass('small', 'a', 'https://creativecommons.org')
-  }</Story>
-</Preview>
+  }}
+  args={{label:'BUTTON'}}
+  >{args => buttonClass('small',args.label,'a', 'https://creativecommons.org')}
+  </Story>
+</Canvas>

--- a/packages/vocabulary/src/stories/buttons.stories.mdx
+++ b/packages/vocabulary/src/stories/buttons.stories.mdx
@@ -19,11 +19,11 @@ export const buttonDonateClass = (classes, label, el = 'button', href='') => {
 
 Buttons are created by adding the `.button` class to a `<button>`.
 
-<Canvas>
+<Canvas mdxSource={buttonClass('','BUTTON')}>
   <Story name="MediumButton" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}
-  args={{label: 'BUTTON'}}
+  args={{label:'BUTTON'}}
   >
   {args => buttonClass('',args.label)}
   </Story>
@@ -31,7 +31,7 @@ Buttons are created by adding the `.button` class to a `<button>`.
 
 You can customize the size of buttons with the `.big`, `.small` and `.tiny` classes.
 
-<Canvas>
+<Canvas mdxSource={buttonClass('big','BUTTON')}>
   <Story name="BigButton" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}
@@ -41,7 +41,7 @@ You can customize the size of buttons with the `.big`, `.small` and `.tiny` clas
   </Story>
 </Canvas>
 
-<Canvas>
+<Canvas mdxSource={buttonClass('small','BUTTON')}>
   <Story name="SmallButton" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}
@@ -49,7 +49,7 @@ You can customize the size of buttons with the `.big`, `.small` and `.tiny` clas
   >{args => buttonClass('small',args.label)}</Story>
 </Canvas>
 
-<Canvas>
+<Canvas mdxSource={buttonClass('tiny','BUTTON')}>
   <Story name="TinyButton" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}
@@ -60,7 +60,7 @@ You can customize the size of buttons with the `.big`, `.small` and `.tiny` clas
 
 You can also combine other classes such as `.is-primary` and `.donate` with the aforementioned size classes.
 
-<Canvas>
+<Canvas mdxSource={buttonClass('is-primary big','BUTTON')}>
   <Story name="ButtonPrimary" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}
@@ -70,7 +70,7 @@ You can also combine other classes such as `.is-primary` and `.donate` with the 
   </Story>
 </Canvas>
 
-<Canvas>
+<Canvas mdxSource={buttonClass('big','BUTTON')}>
   <Story name="ButtonDonateLarge" height="100px" parameters={{
     design: figmaConfig('1404%3A19')
   }}
@@ -79,7 +79,7 @@ You can also combine other classes such as `.is-primary` and `.donate` with the 
   </Story>
 </Canvas>
 
-<Canvas>
+<Canvas mdxSource={buttonDonateClass('medium','BUTTON')}>
   <Story name="ButtonDonateMedium" height="100px" parameters={{
     design: figmaConfig('1404%3A19')
   }}
@@ -88,7 +88,7 @@ You can also combine other classes such as `.is-primary` and `.donate` with the 
   </Story>
 </Canvas>
 
-<Canvas>
+<Canvas mdxSource={buttonDonateClass('small','BUTTON')}>
   <Story name="ButtonDonateNormal" height="100px" parameters={{
     design: figmaConfig('1404%3A19')
   }}
@@ -99,7 +99,7 @@ You can also combine other classes such as `.is-primary` and `.donate` with the 
 
 Buttons may have four feedback colors such as `.is-success`, `.is-info`, `.is-warning` and `.is-danger`.
 
-<Canvas>
+<Canvas mdxSource={buttonClass('is-success','BUTTON')}>
   <Story name="ButtonSuccess" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}
@@ -108,7 +108,7 @@ Buttons may have four feedback colors such as `.is-success`, `.is-info`, `.is-wa
   </Story>
 </Canvas>
 
-<Canvas>
+<Canvas mdxSource={buttonClass('is-info','BUTTON')}>
   <Story name="ButtonInfo" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}
@@ -117,7 +117,7 @@ Buttons may have four feedback colors such as `.is-success`, `.is-info`, `.is-wa
   </Story>
 </Canvas>
 
-<Canvas>
+<Canvas mdxSource={buttonClass('is-warning','BUTTON')}>
   <Story name="ButtonWarning" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}
@@ -126,7 +126,7 @@ Buttons may have four feedback colors such as `.is-success`, `.is-info`, `.is-wa
   </Story>
 </Canvas>
 
-<Canvas>
+<Canvas mdxSource={buttonClass('is-danger','BUTTON')}>
   <Story name="ButtonError" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}
@@ -137,7 +137,7 @@ Buttons may have four feedback colors such as `.is-success`, `.is-info`, `.is-wa
 
 The `.tag` class is used to render a tag name.
 
-<Canvas>
+<Canvas mdxSource={buttonClass('tag','BUTTON')}>
   <Story name="Tag" height="100px" parameters={{
     design: figmaConfig('1404%3A1')
   }}
@@ -159,7 +159,7 @@ The `.tag` class is used to render a tag name.
 
 You can use the `.is-text` to have a button looking more like a link, with no borders and background color.
 
-<Canvas>
+<Canvas mdxSource={buttonClass('is-text','BUTTON')}>
   <Story name="Text" height="100px" parameters={{
     design: figmaConfig('1404%3A1')
   }}
@@ -171,7 +171,7 @@ You can use the `.is-text` to have a button looking more like a link, with no bo
 
 Button styles should be applied to anchor tags (`<a>`) when using links. Avoid using JavaScript and `<button>` tags to replicate anchor tag behavior whenever possible.
 
-<Canvas>
+<Canvas mdxSource={buttonClass('small','BUTTON','a','https://creativecommons.org')}>
   <Story name="Anchor Tags" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}

--- a/packages/vocabulary/src/stories/buttons.stories.mdx
+++ b/packages/vocabulary/src/stories/buttons.stories.mdx
@@ -1,89 +1,111 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
-<Meta title="Elements/Buttons" />
+<Meta title="Elements/Buttons" argTypes={{ label: { control: 'text' } } }/>
 
 # Buttons
 
-export const buttonClass = (classes, el = 'button', href='') => {
- classes = classes ? ` ${classes}` : ''
- return `<${el} ${href ? `href=${href}` : ''} class="button${classes}">Button</${el}>`
+export const buttonClass = (classes, label, el = 'button', href='') => {
+  classes = classes ? `${classes}` : ''
+ return `<${el} ${href ? `href=${href}` : ''} class="button${classes}">${label}</${el}>`
 }
 
-export const buttonDonateClass = (classes, el = 'button', href='') => {
+export const buttonDonateClass = (classes, label, el = 'button', href='') => {
  classes = classes ? ` ${classes}` : ''
  return `<${el} ${href ? `href=${href}` : ''} class="button${classes} donate"> 
  <i class= "icon cc-letterheart-filled margin-right-small padding-top-smaller"></i>
- Button</${el}>`
+ ${label}</${el}>`
 }
+
+export const Template = (args) => buttonClass('',args.label)
+export const Template1 = (args) => buttonDonateClass('big',args.label)
 
 Buttons are created by adding the `.button` class to a `<button>`.
 
-<Preview mdxSource={buttonClass('')}>
+<Preview mdxSource={buttonClass('','BUTTON')}>
   <Story name="MediumButton" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
-  }}>{
-    buttonClass('')
-  }</Story>
+  }}
+  args={{label: 'BUTTON'}}
+  >{
+  Template.bind({})
+  }
+  </Story>
 </Preview>
 
 You can customize the size of buttons with the `.big`, `.small` and `.tiny` classes.
 
-<Preview mdxSource={buttonClass('big')}>
+<Preview mdxSource={buttonClass('big','BUTTON')}>
   <Story name="BigButton" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
-  }}>{
-    buttonClass('big')
+  }}
+  args={{label: 'BUTTON'}}
+  >
+  {
+    Template.bind({})
   }</Story>
 </Preview>
 
-<Preview mdxSource={buttonClass('small')}>
+<Preview mdxSource={buttonClass('small','BUTTON')}>
   <Story name="SmallButton" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
-  }}>{
-    buttonClass('small')
+  }}
+  args={{label: 'BUTTON'}}
+  >{
+    Template.bind({})
   }</Story>
 </Preview>
 
-<Preview mdxSource={buttonClass('tiny')}>
+<Preview mdxSource={buttonClass('tiny','BUTTON')}>
   <Story name="TinyButton" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
-  }}>{
-    buttonClass('tiny')
+  }}
+  args={{label: 'BUTTON'}}
+  >{
+    Template.bind({})
   }</Story>
 </Preview>
 
 You can also combine other classes such as `.is-primary` and `.donate` with the aforementioned size classes.
 
-<Preview mdxSource={buttonClass('is-primary big')}>
+<Preview mdxSource={buttonClass('is-primary big','BUTTON')}>
   <Story name="ButtonPrimary" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
-  }}>{
-    buttonClass('is-primary big')
+  }}
+  args={{label: 'BUTTON'}}
+  >
+  {
+    Template.bind({})
   }</Story>
 </Preview>
 
 <Preview mdxSource={buttonDonateClass('big')}>
   <Story name="ButtonDonateLarge" height="100px" parameters={{
     design: figmaConfig('1404%3A19')
-  }}>{
-    buttonDonateClass('big')
+  }}
+  args={{label: 'BUTTON'}}
+  >{
+    Template1.bind({})
   }</Story>
 </Preview>
 
 <Preview mdxSource={buttonDonateClass('medium')}>
   <Story name="ButtonDonateMedium" height="100px" parameters={{
     design: figmaConfig('1404%3A19')
-  }}>{
-    buttonDonateClass('medium')
+  }}
+  args={{label: 'BUTTON'}}
+  >{
+    Template1.bind({})
   }</Story>
 </Preview>
 
 <Preview mdxSource={buttonDonateClass('small')}>
   <Story name="ButtonDonateNormal" height="100px" parameters={{
     design: figmaConfig('1404%3A19')
-  }}>{
-    buttonDonateClass('small')
+  }}
+  args={{label: 'BUTTON'}}
+  >{
+    Template1.bind({})
   }</Story>
 </Preview>
 


### PR DESCRIPTION
## Fixes
Related to #660 by @nimishbongale 

## Description
This PR attempts to migrate vocabulary to latest storybook standards.

## Technical details 
#### What this PR achieves
- Bumps storybook essentials
- Removes deprecated addons
- Bumps stoybook itself to `6.0.21`
- Adds controls to buttons (label)

#### What this PR doesn't achieve
- The code shown on the `docs` tab is not helpful at the moment. Also `Preview` has been replaced by `Canvas`, and it is not clear how this is supposed to be done now
- Does not add controls to other components (pending a discussion)
- Possible merging of different sizes of buttons into one story. Use controls to change their sizes (pending a discussion)

## Screenshots
![controls](https://user-images.githubusercontent.com/43414361/94371536-e6e9fc80-0114-11eb-8e66-bbb5b87840b5.PNG)
<br>
![controls2](https://user-images.githubusercontent.com/43414361/94371540-efdace00-0114-11eb-929d-c8b261256414.PNG)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
