### PR TITLE
Add focus style to text button

### DIFF
--- a/packages/vocabulary/src/styles/button.scss
+++ b/packages/vocabulary/src/styles/button.scss
@@ -133,5 +133,8 @@ $button-family: $family-secondary;
       box-shadow: none;
       background-color: transparent;
     }
+    &:focus {
+      text-decoration: underline;
+    }
   }
 }

--- a/packages/vocabulary/src/styles/button.scss
+++ b/packages/vocabulary/src/styles/button.scss
@@ -130,8 +130,8 @@ $button-family: $family-secondary;
     &:active,
     &:focus {
       border-color: transparent;
-      box-shadow: none;
       background-color: transparent;
+      box-shadow: none;
     }
     &:focus {
       text-decoration: underline;

--- a/packages/vocabulary/src/styles/button.scss
+++ b/packages/vocabulary/src/styles/button.scss
@@ -130,8 +130,8 @@ $button-family: $family-secondary;
     &:active,
     &:focus {
       border-color: transparent;
-      background-color: transparent;
       box-shadow: none;
+      background-color: transparent;
     }
     &:focus {
       text-decoration: underline;


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #562 by @AyanChoudhary 

## Description
<!-- Concisely describe what the pull request does. -->
Add underline when a Vocabulary text button is focused.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
![textButton](https://user-images.githubusercontent.com/15233243/95507280-dc9fec00-09b9-11eb-9fdb-bc8e6f61b95c.png)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
