### PR TITLE
Implementation of Dark-mode in the storybook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4349,6 +4349,12 @@
       "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
       "dev": true
     },
+    "map-or-similar": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
+      "integrity": "sha1-beJlMXSt+12e3DPGnT6Sobdvrwg=",
+      "dev": true
+    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -4356,6 +4362,15 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "memoizerific": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
+      "integrity": "sha1-fIekZGREwy11Q4VwkF8tvRsagFo=",
+      "dev": true,
+      "requires": {
+        "map-or-similar": "^1.5.0"
       }
     },
     "meow": {
@@ -6132,6 +6147,16 @@
             "is-descriptor": "^0.1.0"
           }
         }
+      }
+    },
+    "storybook-dark-mode": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/storybook-dark-mode/-/storybook-dark-mode-1.0.3.tgz",
+      "integrity": "sha512-mjHLrv/dwtqKmbOoQ2CMtGKDttWSnUybutujsIPxLcEC77EujjWiRBFv46LtXAZEyZLm8sGFUz0s6HJJfJ3tSw==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.0.0",
+        "memoizerific": "^1.11.3"
       }
     },
     "stream-each": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "storybook": "lerna run storybook --parallel"
   },
   "devDependencies": {
-    "lerna": "^3.22.1"
+    "lerna": "^3.22.1",
+    "storybook-dark-mode": "^1.0.3"
   }
 }

--- a/packages/fonts/.storybook/manager.js
+++ b/packages/fonts/.storybook/manager.js
@@ -1,7 +1,8 @@
 import { addons } from '@storybook/addons'
 
-import theme from './theme'
+import { themes } from '@storybook/theming'
+import 'storybook-dark-mode/register'
 
 addons.setConfig({
-  theme
+  theme:themes.light
 })

--- a/packages/vocabulary/.storybook/manager.js
+++ b/packages/vocabulary/.storybook/manager.js
@@ -1,7 +1,8 @@
 import { addons } from '@storybook/addons'
 
-import theme from './theme'
+import { themes } from '@storybook/theming'
+import 'storybook-dark-mode/register'
 
 addons.setConfig({
-  theme
+  theme:themes.light
 })

--- a/packages/vue-vocabulary/.storybook/manager.js
+++ b/packages/vue-vocabulary/.storybook/manager.js
@@ -1,7 +1,8 @@
 import { addons } from '@storybook/addons'
 
-import theme from './theme'
+import { themes } from '@storybook/theming'
+import 'storybook-dark-mode/register'
 
 addons.setConfig({
-  theme
+  theme:themes.light
 })


### PR DESCRIPTION
## Fixes

Fixes #699 by @nimishbongale 

## Description
Implements toggling b/w Dark mode and Light mode in the 3 storybooks `Fonts`, `Vocabulary` and `Vue-Vocabulary` 


## Demo:
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

![ezgif com-gif-maker](https://user-images.githubusercontent.com/56186425/95816634-33505180-0d3d-11eb-94c5-037930904f67.gif)


![sun icon](https://user-images.githubusercontent.com/56186425/95873297-68849000-0d8d-11eb-809f-d70e5c9f7ead.png)
![moonicon](https://user-images.githubusercontent.com/56186425/95873310-6d494400-0d8d-11eb-9249-eecf6deefbb2.png)



## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
