### PR TITLE
add mailchimp form to footer story

### DIFF
--- a/packages/vocabulary/src/stories/footer.stories.mdx
+++ b/packages/vocabulary/src/stories/footer.stories.mdx
@@ -53,10 +53,12 @@ export const footer = () => `
           <div class="column is-two-thirds">
             <div class="subscription">
               <h5 class="b-header">Subscribe to our newsletter</h5>
-              <form class="newsletter">
-                <label for="email" class="is-sr-only">Email to subscribe</label>
-                <input type="text" id="email" class="input" placeholder="Your email">
-                <input type="submit" value="subscribe" class="button small">
+              <form action="https://creativecommons.us4.list-manage.com/subscribe/post?u=fd30364b6577b471373d6076c&amp;id=4603fe102a" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter" target="_blank" novalidate>
+                <label for="mce-EMAIL" class="is-sr-only">Email to subscribe</label>
+                <input type="email" value="" name="EMAIL" class="email input" id="mce-EMAIL" placeholder="Your email" required>
+                <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_fd30364b6577b471373d6076c_4603fe102a" tabindex="-1" value=""></div>
+                <input type="submit" value="subscribe" id="mc-embedded-subscribe" class="button small">
               </form>
             </div>
             <div class="attribution margin-top-bigger">


### PR DESCRIPTION
## Fixes
Fixes https://github.com/creativecommons/tech-support/issues/685 by @victoriaheath

## Description
This PR replaces the current subscribe form with Mailchimp as requested by comms. we may need to update this in our WP theme base and also in other places

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
