### PR TITLE
Add 'normal' and 'disabled' styles to buttons

### DIFF
--- a/packages/vocabulary/src/stories/buttons.stories.mdx
+++ b/packages/vocabulary/src/stories/buttons.stories.mdx
@@ -5,129 +5,110 @@ import { figmaConfig } from './helpers'
 
 # Buttons
 
-export const buttonClass = (classes, el = 'button', href='') => {
- classes = classes ? ` ${classes}` : ''
- return `<${el} ${href ? `href=${href}` : ''} class="button${classes}">Button</${el}>`
+export const defaultOptions = {el: 'button', href: '', label: 'button', disabled: false}
+
+export const defaultButton = (classes, options) => {
+  classes = classes ? ` ${classes}` : ''
+  if (!options) {
+    options = defaultOptions
+  }
+  const el = options.el || 'button'
+  const label = options.label || 'button'
+  const disabled = options.disabled || false
+  const href = options.href || ''
+  return `<${el} ${href ? `href=${href}` : ''}class="button${classes}"${disabled?` disabled`:''}>${label}</${el}>`
+}
+
+export const buttonSources = (classes, isDefaultLabel) => {
+  const options = (className) => !isDefaultLabel ? null : {label: className.replace('is-', '')}
+  return classes.map(className => defaultButton(className, options(className))).join('\n')
 }
 
 export const buttonDonateClass = (classes, el = 'button', href='') => {
  classes = classes ? ` ${classes}` : ''
- return `<${el} ${href ? `href=${href}` : ''} class="button${classes} donate"> 
+ return `<${el} ${href ? `href=${href}` : ''} class="button${classes} donate">
  <i class= "icon cc-letterheart-filled margin-right-small padding-top-smaller"></i>
  Button</${el}>`
 }
 
-Buttons are created by adding the `.button` class to a `<button>`.
+Buttons are created by adding the `.button` class to a `<button>` or an `<a>` element.
+By default, buttons are of `normal` size.
 
-<Preview mdxSource={buttonClass('')}>
-  <Story name="MediumButton" height="100px" parameters={{
+<Preview mdxSource={buttonSources([''])}>
+  <Story name="Button" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}>{
-    buttonClass('')
+    defaultButton('normal')
   }</Story>
 </Preview>
 
-You can customize the size of buttons with the `.big`, `.small` and `.tiny` classes.
+export const sizes = ['big', 'medium', 'normal','small', 'tiny']
 
-<Preview mdxSource={buttonClass('big')}>
-  <Story name="BigButton" height="100px" parameters={{
-    design: figmaConfig('1403%3A61')
-  }}>{
-    buttonClass('big')
-  }</Story>
-</Preview>
+You can customize the size of buttons with the `.big`, `.medium`, `.normal`, `.small` and `.tiny` classes.
 
-<Preview mdxSource={buttonClass('small')}>
-  <Story name="SmallButton" height="100px" parameters={{
+<Preview mdxSource={buttonSources(sizes, true)}>
+  <Story name="Button Sizes" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
-  }}>{
-    buttonClass('small')
-  }</Story>
-</Preview>
-
-<Preview mdxSource={buttonClass('tiny')}>
-  <Story name="TinyButton" height="100px" parameters={{
-    design: figmaConfig('1403%3A61')
-  }}>{
-    buttonClass('tiny')
-  }</Story>
+  }}>
+    {buttonSources(sizes, true)}
+  </Story>
 </Preview>
 
 You can also combine other classes such as `.is-primary` and `.donate` with the aforementioned size classes.
 
-<Preview mdxSource={buttonClass('is-primary big')}>
-  <Story name="ButtonPrimary" height="100px" parameters={{
+export const primarySizes = ['is-primary big', 'is-primary medium', 'is-primary normal', 'is-primary small', 'is-primary tiny']
+
+<Preview mdxSource={buttonSources(primarySizes)}>
+  <Story name="ButtonPrimarySizes" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}>{
-    buttonClass('is-primary big')
+    buttonSources(primarySizes)
   }</Story>
 </Preview>
 
-<Preview mdxSource={buttonDonateClass('big')}>
-  <Story name="ButtonDonateLarge" height="100px" parameters={{
-    design: figmaConfig('1404%3A19')
-  }}>{
-    buttonDonateClass('big')
-  }</Story>
-</Preview>
+export const donateButtonSizes = () => {
+  return ['big', 'medium', 'normal', 'small']
+    .map((classes) => (buttonDonateClass(classes))).join('\n')
+}
 
-<Preview mdxSource={buttonDonateClass('medium')}>
-  <Story name="ButtonDonateMedium" height="100px" parameters={{
+<Preview mdxSource={donateButtonSizes()}>
+  <Story name="ButtonDonate" height="100px" parameters={{
     design: figmaConfig('1404%3A19')
-  }}>{
-    buttonDonateClass('medium')
-  }</Story>
-</Preview>
-
-<Preview mdxSource={buttonDonateClass('small')}>
-  <Story name="ButtonDonateNormal" height="100px" parameters={{
-    design: figmaConfig('1404%3A19')
-  }}>{
-    buttonDonateClass('small')
-  }</Story>
+  }}>
+    {donateButtonSizes()}
+  </Story>
 </Preview>
 
 Buttons may have four feedback colors such as `.is-success`, `.is-info`, `.is-warning` and `.is-danger`.
 
-<Preview mdxSource={buttonClass('is-success')}>
-  <Story name="ButtonSuccess" height="100px" parameters={{
+export const feedbackClasses = ['is-success', 'is-info', 'is-warning', 'is-danger']
+
+<Preview mdxSource={buttonSources(feedbackClasses, true)}>
+  <Story name="ButtonFeedbackTypes" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}>{
-    buttonClass('is-success')
+    buttonSources(feedbackClasses, true)
   }</Story>
 </Preview>
 
-<Preview mdxSource={buttonClass('is-info')}>
-  <Story name="ButtonInfo" height="100px" parameters={{
+Buttons can be disabled:
+
+<Preview mdxSource={defaultButton('', {disabled: true})}>
+  <Story name="ButtonDisabled" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}>{
-    buttonClass('is-info')
+    defaultButton('', {disabled: true})
   }</Story>
 </Preview>
 
-<Preview mdxSource={buttonClass('is-warning')}>
-  <Story name="ButtonWarning" height="100px" parameters={{
-    design: figmaConfig('1403%3A61')
-  }}>{
-    buttonClass('is-warning')
-  }</Story>
-</Preview>
-
-<Preview mdxSource={buttonClass('is-danger')}>
-  <Story name="ButtonError" height="100px" parameters={{
-    design: figmaConfig('1403%3A61')
-  }}>{
-    buttonClass('is-danger')
-  }</Story>
-</Preview>
 
 The `.tag` class is used to render a tag name.
 
-<Preview mdxSource={buttonClass('tag')}>
+<Preview mdxSource={defaultButton('tag')}>
   <Story name="Tag" height="100px" parameters={{
     design: figmaConfig('1404%3A1')
   }}>{
-    buttonClass('tag')
+    defaultButton('tag')
   }</Story>
 </Preview>
 
@@ -144,20 +125,20 @@ The `.tag` class is used to render a tag name.
 
 You can use the `.is-text` to have a button looking more like a link, with no borders and background color.
 
-<Preview mdxSource={buttonClass('is-text')}>
+<Preview mdxSource={defaultButton('is-text')}>
   <Story name="Text" height="100px" parameters={{
     design: figmaConfig('1404%3A1')
   }}>{
-    buttonClass('is-text')
+    defaultButton('is-text')
   }</Story>
 </Preview>
 
 Button styles should be applied to anchor tags (`<a>`) when using links. Avoid using JavaScript and `<button>` tags to replicate anchor tag behavior whenever possible.
 
-<Preview mdxSource={buttonClass('small', 'a', 'https://creativecommons.org')}>
+<Preview mdxSource={defaultButton('small', 'a', 'https://creativecommons.org')}>
   <Story name="Anchor Tags" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}>{
-    buttonClass('small', 'a', 'https://creativecommons.org')
+    defaultButton('small', 'a', 'https://creativecommons.org')
   }</Story>
 </Preview>

--- a/packages/vocabulary/src/styles/button.scss
+++ b/packages/vocabulary/src/styles/button.scss
@@ -9,8 +9,8 @@ $button-family: $family-secondary;
   border: 0.125rem solid $color-dark-gray;
   color: $color-dark-gray;
   background-color: $color-white;
-  font-size: 1.43rem;
-  padding: calc(#{$space-bigger} - 0.187rem) $space-large;
+  font-size: 1.125rem;
+  padding: $space-small $space-normal;
 
   &:hover {
     background-color: $color-dark-gray;
@@ -19,7 +19,7 @@ $button-family: $family-secondary;
     text-decoration: none;
   }
 
-  &.disabled {
+  &[disabled] {
     background-color: $color-light-gray;
     color: $color-dark-gray;
   }
@@ -29,9 +29,9 @@ $button-family: $family-secondary;
     padding: calc(#{$space-large} - 0.093rem) $space-large;
   }
 
-  &.normal {
-    font-size: 1.125rem;
-    padding: $space-small $space-normal;
+  &.medium {
+    font-size: 1.43rem;
+    padding: calc(#{$space-bigger} - 0.187rem) $space-large;
   }
 
   &.small {
@@ -117,7 +117,7 @@ $button-family: $family-secondary;
   }
 
   &.is-info:hover {
-    background-color: $color-brighter-dark-slate-blue;
+    background-color: $color-dark-slate-blue;
   }
 
   &.donate {
@@ -151,7 +151,7 @@ $button-family: $family-secondary;
     &:focus {
       text-decoration: underline;
     }
-    &.disabled {
+    &[disabled] {
       color: $color-gray;
     }
   }

--- a/packages/vocabulary/src/styles/button.scss
+++ b/packages/vocabulary/src/styles/button.scss
@@ -19,9 +19,19 @@ $button-family: $family-secondary;
     text-decoration: none;
   }
 
+  &.disabled {
+    background-color: $color-light-gray;
+    color: $color-dark-gray;
+  }
+
   &.big {
     font-size: 1.75rem;
     padding: calc(#{$space-large} - 0.093rem) $space-large;
+  }
+
+  &.normal {
+    font-size: 1.125rem;
+    padding: $space-small $space-normal;
   }
 
   &.small {
@@ -35,6 +45,11 @@ $button-family: $family-secondary;
     font-size: 1rem;
     text-transform: none;
     height: 2rem;
+  }
+
+  &.border {
+    border-color: $color-dark-gray;
+    background-color: $color-white;
   }
 
   &.tag {
@@ -102,7 +117,7 @@ $button-family: $family-secondary;
   }
 
   &.is-info:hover {
-    background-color: $color-dark-slate-blue;
+    background-color: $color-brighter-dark-slate-blue;
   }
 
   &.donate {
@@ -135,6 +150,9 @@ $button-family: $family-secondary;
     }
     &:focus {
       text-decoration: underline;
+    }
+    &.disabled {
+      color: $color-gray;
     }
   }
 }


### PR DESCRIPTION
## Related to Chooser#199

## Description
<!-- Concisely describe what the pull request does. -->
This PR adds styles for 'normal'-sized button and `disabled` buttons. Normal-sized buttons are used in Chooser's stepper ('Previous' - 'Next')



## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
![AddedButtonStyles](https://user-images.githubusercontent.com/15233243/97632149-5c383e00-19ef-11eb-8bed-6a5fc812f437.png)
## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
