### PR TITLE
Make 'is-primary' the default button

### DIFF
--- a/packages/vocabulary/src/stories/buttons.stories.mdx
+++ b/packages/vocabulary/src/stories/buttons.stories.mdx
@@ -31,8 +31,8 @@ export const buttonDonateClass = (classes, el = 'button', href='') => {
  Button</${el}>`
 }
 
-Buttons are created by adding the `.button` class to a `<button>` or an `<a>` element.
-By default, buttons are of `normal` size.
+To create buttons, add the `.button` class to a `<button>` or an `<a>` element.
+By default, buttons are of `normal` size and `primary` theme.
 
 <Preview mdxSource={buttonSources([''])}>
   <Story name="Button" height="100px" parameters={{
@@ -54,17 +54,7 @@ You can customize the size of buttons with the `.big`, `.medium`, `.normal`, `.s
   </Story>
 </Preview>
 
-You can also combine other classes such as `.is-primary` and `.donate` with the aforementioned size classes.
-
-export const primarySizes = ['is-primary big', 'is-primary medium', 'is-primary normal', 'is-primary small', 'is-primary tiny']
-
-<Preview mdxSource={buttonSources(primarySizes)}>
-  <Story name="ButtonPrimarySizes" height="100px" parameters={{
-    design: figmaConfig('1403%3A61')
-  }}>{
-    buttonSources(primarySizes)
-  }</Story>
-</Preview>
+You can also combine other classes such as `.donate` with the aforementioned size classes.
 
 export const donateButtonSizes = () => {
   return ['big', 'medium', 'normal', 'small']
@@ -79,9 +69,9 @@ export const donateButtonSizes = () => {
   </Story>
 </Preview>
 
-Buttons may have four feedback colors such as `.is-success`, `.is-info`, `.is-warning` and `.is-danger`.
+Buttons may have four feedback colors such as `.is-success`, `.is-info`, `.is-warning`, `.is-danger`, and `is-border`.
 
-export const feedbackClasses = ['is-success', 'is-info', 'is-warning', 'is-danger']
+export const feedbackClasses = ['is-success', 'is-info', 'is-warning', 'is-danger', 'is-border']
 
 <Preview mdxSource={buttonSources(feedbackClasses, true)}>
   <Story name="ButtonFeedbackTypes" height="100px" parameters={{

--- a/packages/vocabulary/src/styles/button.scss
+++ b/packages/vocabulary/src/styles/button.scss
@@ -6,17 +6,22 @@ $button-family: $family-secondary;
   text-transform: uppercase;
   font-weight: 600;
   line-height: 0;
-  border: 0.125rem solid $color-dark-gray;
-  color: $color-dark-gray;
-  background-color: $color-white;
+  background-color: $color-tomato;
+  color: var(--button-color, #fff);
+  border: 0.125rem solid var(--button-border-color, transparent);
   font-size: 1.125rem;
   padding: $space-small $space-normal;
 
-  &:hover {
-    background-color: $color-dark-gray;
-    border-color: $color-dark-gray;
-    color: $color-white;
+  &:hover,
+  &:active,
+  &:focus {
+    color: #fff;
+    background-color: $color-brighter-tomato;
     text-decoration: none;
+    border-color: transparent;
+  }
+  &:focus, &:focus:not(:active) {
+    box-shadow: 0 0 0 0.125em var(--button-focus-outline, rgba(226,54,0,.25));
   }
 
   &[disabled] {
@@ -45,11 +50,6 @@ $button-family: $family-secondary;
     font-size: 1rem;
     text-transform: none;
     height: 2rem;
-  }
-
-  &.border {
-    border-color: $color-dark-gray;
-    background-color: $color-white;
   }
 
   &.tag {
@@ -108,16 +108,39 @@ $button-family: $family-secondary;
     }
   }
 
-  &.is-primary:hover {
-    background-color: $color-brighter-tomato;
+  &.is-border {
+    border: 0.125rem solid $color-dark-gray;
+    color: $color-dark-gray;
+    background-color: $color-white;
+    &:hover, &:active {
+      background-color: $color-dark-gray;
+      border-color: $color-dark-gray;
+      color: $color-white;
+    }
+    &:focus {
+      --button-focus-outline: rgb(176, 176, 176);
+    }
   }
 
-  &.is-success:hover {
-    background-color: $color-brighter-forest-green;
+  &.is-primary {
+    --button-focus-outline: #{$color-lighter-gray};
+    &:hover, &:focus, &:active {
+      background-color: $color-brighter-tomato;
+    }
   }
 
-  &.is-info:hover {
-    background-color: $color-dark-slate-blue;
+  &.is-success {
+    --button-focus-outline: #{$color-lighter-gray};
+    &:hover, &:focus, &:active {
+      background-color: $color-brighter-forest-green;
+    }
+  }
+
+  &.is-info {
+    --button-focus-outline: #{$color-lighter-gray};
+    &:hover, &:focus, &:active {
+      background-color: $color-dark-slate-blue;
+    }
   }
 
   &.donate {
@@ -125,7 +148,7 @@ $button-family: $family-secondary;
     border-color: $color-gold;
     color: $color-black;
 
-    &:hover {
+    &:hover, &:active, &:focus {
       background-color: $color-brighter-gold;
       border-color: $color-brighter-gold;
       color: $color-black;

--- a/packages/vocabulary/src/styles/footer.scss
+++ b/packages/vocabulary/src/styles/footer.scss
@@ -2,7 +2,7 @@
   background-color: $color-black;
   color: $white;
   padding: $space-large 0;
-
+  --button-focus-outline: #fff;
   a {
     color: $color-dark-turquoise;
 
@@ -64,7 +64,7 @@
         background-color: transparent;
         border-color: $color-dark-gray;
         color: $color-dark-gray;
-        
+
         &::placeholder {
           color: $color-dark-gray;
           opacity: 0.8;

--- a/packages/vue-vocabulary/src/elements/Button/Button.stories.js
+++ b/packages/vue-vocabulary/src/elements/Button/Button.stories.js
@@ -22,6 +22,13 @@ const Template = (args, { argTypes }) => ({
 })
 
 export const Default = Template.bind({})
+Default.parameters = {
+  docs: {
+    source: {
+      code: `<Button>Text</Button>`
+    }
+  }
+}
 
 export const Theme = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
@@ -36,10 +43,24 @@ export const Theme = (args, { argTypes }) => ({
 })
 addDescription(Theme, 'Buttons can be styled with various colors. The primary button should be used for major site actions. There should rarely be more than one primary button per page.')
 Theme.args = {}
+Theme.parameters = {
+  docs: {
+    source: {
+      code: `<Button theme="primary">Primary</Button>
+<Button theme="success">Success</Button>
+<Button theme="info">Info</Button>
+<Button theme="warning">Warning</Button>
+<Button theme="danger">Danger</Button>`
+    }
+  }
+}
 
 export const Link = Template.bind({})
 addDescription(Link, 'Buttons with `href` props will be rendered as anchor tags.')
 Link.args = { href: 'https://creativecommons.org', target: '_blank' }
+Link.parameters = {
+  docs: { source: { code: `<Button href="https://creativecommons.org" target: "_blank">Button</Button>` } }
+}
 
 export const Text = Template.bind({})
 addDescription(Text, 'Text buttons lack background color or border.')

--- a/packages/vue-vocabulary/src/elements/Button/Button.stories.js
+++ b/packages/vue-vocabulary/src/elements/Button/Button.stories.js
@@ -22,13 +22,6 @@ const Template = (args, { argTypes }) => ({
 })
 
 export const Default = Template.bind({})
-Default.parameters = {
-  docs: {
-    source: {
-      code: `<Button>Text</Button>`
-    }
-  }
-}
 
 export const Theme = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
@@ -43,24 +36,10 @@ export const Theme = (args, { argTypes }) => ({
 })
 addDescription(Theme, 'Buttons can be styled with various colors. The primary button should be used for major site actions. There should rarely be more than one primary button per page.')
 Theme.args = {}
-Theme.parameters = {
-  docs: {
-    source: {
-      code: `<Button theme="primary">Primary</Button>
-<Button theme="success">Success</Button>
-<Button theme="info">Info</Button>
-<Button theme="warning">Warning</Button>
-<Button theme="danger">Danger</Button>`
-    }
-  }
-}
 
 export const Link = Template.bind({})
 addDescription(Link, 'Buttons with `href` props will be rendered as anchor tags.')
 Link.args = { href: 'https://creativecommons.org', target: '_blank' }
-Link.parameters = {
-  docs: { source: { code: `<Button href="https://creativecommons.org" target: "_blank">Button</Button>` } }
-}
 
 export const Text = Template.bind({})
 addDescription(Text, 'Text buttons lack background color or border.')


### PR DESCRIPTION
## Description
This PR makes the default Vocabulary button the one with 'is-primary' background instead of the 'is-border' one, in accordance with Figma mockups. 

In addition, it introduces the use of CSS custom properties, aka CSS variables to make it easier to adjust properties based on where the buttons are used. E.g., in the footer, where the background is black, changing one property `--button-focus-outline` to white sets all `border-box` declarations for showing the focus of the button white, without the need to find specific buttons and apply the style to each of them.



## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
