### PR TITLE
Create Monorepo Document Story

### DIFF
--- a/packages/vocabulary/.storybook/meta/structure.stories.mdx
+++ b/packages/vocabulary/.storybook/meta/structure.stories.mdx
@@ -1,0 +1,35 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Vocabulary/Structure" />
+
+# Why is Vocabulary a monorepo?
+
+> The tool for managing the monorepo in Vocabulary has been extracted out as [Lerna](https://github.com/lerna/lerna).
+
+`Vocabulary` follows a monorepo approach. All maintained modules are a part of the same repository.
+
+## Rationale
+
+-  The three repositories have a  **strong**  dependency chain so storing them together makes some implicit sense.
+-  The relation between a `2020.8.1` release of `Fonts` and a `2020.8.5` release of `Vocabulary` is arbitrary.
+-  The release process is long, convoluted, and involves releasing each project manually in line from `Fonts` to `Vue-Vocabulary`.  
+-   Documentation is scattered across 3 repositories, making it harder to create internal links.
+-   Unified documentation & the landing site could then be placed in the monorepo.
+
+### Pros
+
+- Unfified Lint, Run, Build & Release Processes.
+- Easier management of dependencies across your packages.
+- Easy to coordinate changes across modules.
+- Single place for easier code review of features that span more than one package.
+- Easier to setup a development environment.
+- Tests across modules are run together which finds bugs that touch multiple modules more easily.
+
+### Cons
+ * Codebase looks more intimidating.
+ * Repository is bigger in size due to the presence of individual packages.
+ * Difficult to account for previous individual contributions (git histories) within the same repository.
+
+## Conclusion
+
+`Vocabulary`, `Fonts` and `Vue-Vocabulary` are now packages present in one _unified_ monorepo. They are however, separate npm packages.

--- a/packages/vocabulary/.storybook/meta/structure.stories.mdx
+++ b/packages/vocabulary/.storybook/meta/structure.stories.mdx
@@ -4,7 +4,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 # Why is Vocabulary a monorepo?
 
-> The tool for managing the monorepo in Vocabulary has been extracted out as [Lerna](https://github.com/lerna/lerna).
+> The tool for managing the monorepo in Vocabulary has been extracted out as [Lerna](https://github.com/lerna/lerna)
 
 `Vocabulary` follows a monorepo approach. All maintained modules are a part of the same repository.
 
@@ -26,6 +26,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 - Tests across modules are run together which finds bugs that touch multiple modules more easily.
 
 ### Cons
+
  * Codebase looks more intimidating.
  * Repository is bigger in size due to the presence of individual packages.
  * Difficult to account for previous individual contributions (git histories) within the same repository.

--- a/packages/vocabulary/.storybook/order.js
+++ b/packages/vocabulary/.storybook/order.js
@@ -3,6 +3,7 @@ const order = {
     'Introduction',
     'Overview',
     'Usage',
+    'Structure',
     'Contribution'
   ],
   'Tokens': [


### PR DESCRIPTION
## Fixes
Fixes #627 by @zackkrida

## Description
Adds the monorepo documentation as a part of `Structure` story.

## Screenshot
![monorepo](https://user-images.githubusercontent.com/43414361/99044856-701a9d00-25b6-11eb-8b21-f82b354f3a37.png)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
