### PR TITLE
Fix locale style regression in the site header

### DIFF
--- a/packages/fonts/src/stories/vocabulary_svg_icons.stories.mdx
+++ b/packages/fonts/src/stories/vocabulary_svg_icons.stories.mdx
@@ -43,7 +43,7 @@ export const angles = Object.keys(iconGroups.arrows.angles)
 
 export const carets = Object.keys(iconGroups.arrows.carets)
 
-<IconSet icons={angles} />
+<IconSet icons={carets} />
 
 ### Chevrons
 

--- a/packages/vocabulary/src/stories/helpers.js
+++ b/packages/vocabulary/src/stories/helpers.js
@@ -40,21 +40,26 @@ export const header = (color) => `<header>
         <div class="navbar-menu is-active">
           <div class="navbar-start">
             <div class="locale">
-              <div class="control has-icons-left">
-                <div class="select is-small">
-                  <select>
-                    <option disabled>Select</option>
-                    <option selected>English</option>
-                    <option>le Français</option>
-                    <option>日本語</option>
-                    <option>Русский</option>
-                    <option>Español</option>
-                  </select>
-                </div>
-                <div class="icon globe is-small is-left ">
-                  <i class="icon globe ">locale</i>
-                </div>
+              <span class="icon globe is-small is-left">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30"><path d="M20.186 9.375C19.335 4.143 17.332.469 15 .469s-4.336 3.674-5.186 8.906h10.372zM9.375 15c0 1.3.07 2.549.193 3.75h10.858a36.74 36.74 0 00.193-3.75c0-1.3-.07-2.549-.193-3.75H9.568A36.725 36.725 0 009.375 15zM28.4 9.375a14.562 14.562 0 00-9.257-8.297c1.43 1.98 2.414 4.963 2.93 8.297H28.4zM10.852 1.078A14.552 14.552 0 001.6 9.375h6.328c.51-3.334 1.494-6.316 2.924-8.297zM29.027 11.25h-6.72c.123 1.23.193 2.49.193 3.75 0 1.26-.07 2.52-.193 3.75h6.715c.322-1.201.503-2.45.503-3.75 0-1.3-.181-2.549-.498-3.75zM7.5 15c0-1.26.07-2.52.193-3.75H.973A14.66 14.66 0 00.469 15c0 1.3.187 2.549.504 3.75h6.715A39.675 39.675 0 017.5 15zm2.314 5.625c.85 5.232 2.854 8.906 5.186 8.906s4.336-3.674 5.186-8.906H9.814zm9.334 8.297a14.576 14.576 0 009.258-8.297h-6.328c-.515 3.334-1.5 6.316-2.93 8.297zM1.6 20.625a14.562 14.562 0 009.257 8.297c-1.43-1.98-2.414-4.963-2.93-8.297H1.6z" fill="currentColor"/></svg>
+              </span>
+              <div class="select">
+                <select>
+                  <option disabled>
+                    <!--<span class="icon globe is-small is-left">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30"><path d="M20.186 9.375C19.335 4.143 17.332.469 15 .469s-4.336 3.674-5.186 8.906h10.372zM9.375 15c0 1.3.07 2.549.193 3.75h10.858a36.74 36.74 0 00.193-3.75c0-1.3-.07-2.549-.193-3.75H9.568A36.725 36.725 0 009.375 15zM28.4 9.375a14.562 14.562 0 00-9.257-8.297c1.43 1.98 2.414 4.963 2.93 8.297H28.4zM10.852 1.078A14.552 14.552 0 001.6 9.375h6.328c.51-3.334 1.494-6.316 2.924-8.297zM29.027 11.25h-6.72c.123 1.23.193 2.49.193 3.75 0 1.26-.07 2.52-.193 3.75h6.715c.322-1.201.503-2.45.503-3.75 0-1.3-.181-2.549-.498-3.75zM7.5 15c0-1.26.07-2.52.193-3.75H.973A14.66 14.66 0 00.469 15c0 1.3.187 2.549.504 3.75h6.715A39.675 39.675 0 017.5 15zm2.314 5.625c.85 5.232 2.854 8.906 5.186 8.906s4.336-3.674 5.186-8.906H9.814zm9.334 8.297a14.576 14.576 0 009.258-8.297h-6.328c-.515 3.334-1.5 6.316-2.93 8.297zM1.6 20.625a14.562 14.562 0 009.257 8.297c-1.43-1.98-2.414-4.963-2.93-8.297H1.6z" fill="currentColor"/></svg>
+                    </span>-->
+                    Select</option>
+                  <option selected>English</option>
+                  <option>le Français</option>
+                  <option>日本語</option>
+                  <option>Русский</option>
+                  <option>Español</option>
+                </select>
               </div>
+              <span class="icon caret-down is-small is-right">
+                <svg viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg"><path d="M7.45896 11.25H22.5351c1.043 0 1.5645 1.2598.8262 1.998l-7.5352 7.5411c-.457.457-1.2011.457-1.6582 0L6.63279 13.248c-.73828-.7382-.2168-1.998.82617-1.998z" fill="currentColor"/></svg>
+              </span>
             </div>
             <a class="button donate" href="http://creativecommons.org/donate">
               <i class="icon heart"></i>
@@ -86,7 +91,7 @@ export const header = (color) => `<header>
                 </div>
               </div>
               <div class="tabs-panel explore"></div>
-            </div> 
+            </div>
           </div>
           <div class="navbar-end main-nav">
             <div class="navbar-item has-dropdown is-hoverable">

--- a/packages/vocabulary/src/styles/header.scss
+++ b/packages/vocabulary/src/styles/header.scss
@@ -10,38 +10,32 @@ $navbar-breakpoint: $tablet;
 
 @import 'bulma/sass/components/navbar.sass';
 
+.navbar.is-default .navbar-brand {
+	padding: $space-small 1.375rem 0;
+	.logo {
+		width: 7rem;
+		height: 3.5rem;
+	}
+	.navbar-burger span {
+		width: 18px;
+		height: 3px;
+		left: calc(50% + 8px);
+	}
+	.navbar-burger {
+		width: 3.25rem;
+		top: -$space-small;
+		color: $grey;
+	}
+}
 .navbar {
 	&.is-default {
-		.navbar-brand {
-			padding: $space-small 1.375rem 0;
-			.logo {
-				width: 7rem;
-				height: 3.5rem;
-			}
-			.navbar-burger span {
-				width: 18px;
-				height: 3px;
-				left: calc(50% + 8px);
-			}
-			.navbar-burger {
-				width: 3.25rem;
-				top: -$space-small;
-				color: $grey;
-			}
-		}
 		.navbar-menu {
+			--button-outline-color: white;
 			background-color: $black;
 			padding: $space-smaller 0 0;
 			.navbar-start {
 				padding: 0 0.9rem $space-small;
-				.locale {
-					select {
-						border: 2px solid $white;
-					}
-					.is-small {
-						font-size: 0.813rem;
-					}
-				}
+
 				.donate {
 					display: none;
 					font-family: $family-source-sans-pro;
@@ -185,15 +179,7 @@ $navbar-breakpoint: $tablet;
 					top: -$space-larger;
 					column-gap: $space-normal;
 					padding: $space-small 1.25rem 0;
-					.locale {
-						select {
-							background-color: $color-lighter-gray;
-							border: 2px solid $color-lighter-gray;
-						}
-						.is-small {
-							font-size: 0.75rem;
-						}
-					}
+
 					.donate {
 						display: block;
 					}
@@ -258,14 +244,9 @@ $navbar-breakpoint: $tablet;
 			padding: $space-small 5.75rem $space-big 3.75rem;
 		}
 	}
-	.hide {
-		display: none;
-	}
 
 	&.is-compact {
-		@extend .padding-vertical-normal;
-		@extend .padding-horizontal-bigger;
-
+		padding: $space-bigger $space-normal;
 		height: 72px;
 		display: flex;
 
@@ -315,4 +296,8 @@ $navbar-breakpoint: $tablet;
 			}
 		}
 	}
+}
+
+.navbar.hide {
+	display: none;
 }

--- a/packages/vocabulary/src/styles/header.scss
+++ b/packages/vocabulary/src/styles/header.scss
@@ -45,7 +45,8 @@ $navbar-breakpoint: $tablet;
 					border-color: $color-soft-tomato;
 					line-height: 19px;
 					font-size: 0.75rem;
-					padding: $space-smaller $space-small $space-small $space-smaller;
+					padding: calc(#{$space-smaller} - 0.7px) $space-small calc(#{$space-smaller} - 0.7px) $space-smaller;
+					height: unset;
 					.icon {
 						font-size: 0.6rem;
 						margin-left: $space-smaller;

--- a/packages/vocabulary/src/styles/locale.scss
+++ b/packages/vocabulary/src/styles/locale.scss
@@ -1,17 +1,76 @@
-.locale {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-
+.navbar .locale {
+  position:relative;
+  height: fit-content;
+  border-radius: 4px;
   font-family: $family-source-sans-pro;
 
-  .select {
-    margin-left: $space-small;
+  .select:not(.is-multiple):not(.is-loading){
+    height: unset;
+    select:not(.is-multiple):not(.is-loading) {
+      border-color: transparent;
+      border-width: 0.125rem;
+      width: 8.125rem;
+      padding: $space-smaller $space-big $space-smaller 1.75rem;
+      height: unset;
+      line-height: 1.118rem;
+      font-size: 0.813rem;
+      font-weight: 700;
+      &:focus,
+      &:active,
+      &:hover {
+        border-color: #b0b0b0;
+        outline: none;
+      }
+    }
+
+    &:not(.is-multiple):not(.is-loading)::after {
+      content: unset;
+    }
   }
+
   .icon {
-    align-items: center;
-    display: inline-flex;
-    justify-content: center;
-    padding-left: 10px;
+    position: absolute;
+    top: 0;
+    height: 100%;
+    display:flex;
+    align-items:center;
+    pointer-events: none;
+    &.is-right {
+      left: 6.5rem;
+    }
+    &.is-left {
+     left:0.625rem;
+    }
+    & svg {
+      height: 0.625rem;
+      width: auto;
+    }
+    &.caret-down {
+      color: black;
+      & svg {
+        height: 0.938rem;
+      }
+    }
+    &.globe {
+      z-index:1;
+      color: $color-gray;
+    }
+  }
+  @include tablet() {
+    background-color: $color-lighter-gray;
+    .select:not(.is-multiple):not(.is-loading) {
+      select:not(.is-multiple):not(.is-loading) {
+        width: 100%;
+        font-size: 0.75rem;
+        background-color: $color-lighter-gray;
+      }
+      &:not(.is-multiple):not(.is-loading)::after {
+         content: unset;
+       }
+    }
+    .icon.is-right {
+      right: 0.625rem;
+    }
   }
 }
+

--- a/packages/vocabulary/src/styles/locale.scss
+++ b/packages/vocabulary/src/styles/locale.scss
@@ -10,7 +10,7 @@
       border-color: transparent;
       border-width: 0.125rem;
       width: 8.125rem;
-      padding: $space-smaller $space-big $space-smaller 1.75rem;
+      padding: calc(#{$space-smaller} - 1.3px) calc(#{$space-big} - 1.3px) calc(#{$space-smaller} - 1.3px) 1.7rem;
       height: unset;
       line-height: 1.118rem;
       font-size: 0.813rem;

--- a/packages/vocabulary/src/styles/locale.scss
+++ b/packages/vocabulary/src/styles/locale.scss
@@ -47,8 +47,11 @@
     }
     &.caret-down {
       color: black;
+      width: 0.938rem;
+
       & svg {
         height: 0.938rem;
+        width: auto;
       }
     }
     &.globe {
@@ -70,6 +73,7 @@
     }
     .icon.is-right {
       right: 0.625rem;
+      left: unset;
     }
   }
 }


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #795  by @zackkrida 

## Description
<!-- Concisely describe what the pull request does. -->
All locale styles were extracted from the `header.scss` to `locale.scss`, and rewritten to fix the height and width of the dropdown. I also used inline SVG for the globe icon and caret down. 

This PR also contains a small bug fix in SVG icon stories (to show carets instead of angles in the Carets section).

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
