### PR TITLE
Remove i18n

### DIFF
--- a/packages/vue-vocabulary/src/patterns/AppModal/AppModal.vue
+++ b/packages/vue-vocabulary/src/patterns/AppModal/AppModal.vue
@@ -13,7 +13,7 @@
           <button
             type="button"
             class="close-button has-color-gray is-size-6 is-size-4-touch"
-            :aria-label="$t('browse-page.aria.close')"
+            :aria-label="ariaCloseLabel"
             @click="$emit('close')"
           >
             <span class="icon has-color-gray is-size-4 is-size-6-touch">
@@ -37,7 +37,11 @@
     },
     props: {
       /** Required for titlebar AND close button to show */
-      title: String
+      title: String,
+      ariaCloseLabel: {
+        type: String,
+        default: 'close'
+      }
     },
     mounted () {
       document.addEventListener('keyup', this.closeOnEsc)

--- a/packages/vue-vocabulary/src/patterns/VHeader/VHeader.stories.js
+++ b/packages/vue-vocabulary/src/patterns/VHeader/VHeader.stories.js
@@ -44,11 +44,13 @@ export const IntlHeader = (args, { argTypes }) => ({
   components: { VHeader, NavItem, ChooserLogo },
   template: `<VHeader v-bind="$props">
 <template #menu-items>
-<NavItem tag="a" href="/menu_item" :label="$t('Menu Item')" />
-<NavItem tag="a" href="/menu_item" :label="$t('Menu Item')" :isExternal="true" />
+<NavItem tag="a" href="/menu_item" label="Меню 1" />
+<NavItem tag="a" href="/menu_item" label="Меню 2" :isExternal="true" />
 </template></VHeader>`
 })
+IntlHeader.args = { ariaPrimaryLabel: 'Основная', ariaMenuLabel: 'Меню' }
+
 addDescription(
   IntlHeader,
-  'When using i18n, you should pass translated strings to the header'
+  'When using i18n, you should pass translated strings to the header. Header has two aria labels that need to be bound to it if the language is not English.'
 )

--- a/packages/vue-vocabulary/src/patterns/VHeader/VHeader.vue
+++ b/packages/vue-vocabulary/src/patterns/VHeader/VHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <header class="vocab header">
-    <nav class="navbar" :aria-label="$t('header.aria.primary')">
+    <nav class="navbar" :aria-label="ariaPrimaryLabel">
       <div class="navbar-brand has-color-white">
         <a class="logo" href="/">
           <!--@slot The Vue component with the site's logo -->
@@ -11,7 +11,7 @@
         <a
           role="button"
           :class="{ ['navbar-burger']: true, ['is-active']: isBurgerMenuActive }"
-          :aria-label="$t('header.aria.menu')"
+          :aria-label="ariaMenuLabel"
           aria-expanded="false"
           @click="toggleBurgerActive"
           @keyup.enter="toggleBurgerActive"
@@ -55,6 +55,16 @@
       CCSearchLogo,
       NavItem,
       NavDropdown
+    },
+    props: {
+      ariaPrimaryLabel: {
+        type: String,
+        default: 'Main'
+      },
+      ariaMenuLabel: {
+        type: String,
+        default: 'Menu'
+      }
     },
     data: () => ({ isBurgerMenuActive: false }),
     methods: {


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #823 by @zackkrida 

## Description
<!-- Concisely describe what the pull request does. -->
This PR removes the i18n instance from Vue Vocabulary. The users of the library usually have their own i18n instance and will use it. This is not a problem for text anyway, because the text is passed in slots, however, there are some texts in aria labels that need to be passed as props to the component itself. This PR proposes the following API:

`const translations = { ariaCloseLabel: "закрыть" }`

```vue
<AppModal title="$t('modal-title')" v-bind="translations" />
```
[Binding an object without an argument](https://vuejs.org/v2/guide/components-props.html#Passing-the-Properties-of-an-Object) like this (i.e. `v-bind="translations"` instead of `v-bind:translations=translations`) makes the object properties behave like props inside the component. So, the AppModal component, in turn, has the following prop:

```vue
props: {
  ariaCloseLabel: {
    type: String,
    default: 'close'
  }
}
```

This way, the translations have to be passed when non-default language is used, otherwise, the labels will be in English.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
