### PR TITLE
Added Footer Component

### DIFF
--- a/packages/vue-vocabulary/src/index.js
+++ b/packages/vue-vocabulary/src/index.js
@@ -15,7 +15,7 @@ import Tab from './layouts/Tabs/Tab'
 import Tabs from './layouts/Tabs/Tabs'
 import AppModal from './patterns/AppModal/AppModal'
 import Footer from './patterns/Footer/Footer'
-import FooterLinks from './patterns/Footer/FooterLinks'
+import FooterLink from './patterns/Footer/FooterLink'
 import Locale from './patterns/Locale/Locale'
 import NavDropdown from './patterns/VHeader/NavDropdown'
 import NavItem from './patterns/VHeader/NavItem'
@@ -34,7 +34,7 @@ export {
   Tabs,
   AppModal,
   Footer,
-  FooterLinks,
+  FooterLink,
   Locale,
   NavDropdown,
   NavItem,
@@ -55,7 +55,7 @@ export default {
     Vue.component('Tabs', Tabs)
     Vue.component('AppModal', AppModal)
     Vue.component('Footer', Footer)
-    Vue.component('FooterLinks', FooterLinks)
+    Vue.component('FooterLink', FooterLink)
     Vue.component('Locale', Locale)
     Vue.component('NavDropdown', NavDropdown)
     Vue.component('NavItem', NavItem)

--- a/packages/vue-vocabulary/src/index.js
+++ b/packages/vue-vocabulary/src/index.js
@@ -15,6 +15,7 @@ import Tab from './layouts/Tabs/Tab'
 import Tabs from './layouts/Tabs/Tabs'
 import AppModal from './patterns/AppModal/AppModal'
 import Footer from './patterns/Footer/Footer'
+import FooterLinks from './patterns/Footer/FooterLinks'
 import Locale from './patterns/Locale/Locale'
 import NavDropdown from './patterns/VHeader/NavDropdown'
 import NavItem from './patterns/VHeader/NavItem'
@@ -33,6 +34,7 @@ export {
   Tabs,
   AppModal,
   Footer,
+  FooterLinks,
   Locale,
   NavDropdown,
   NavItem,
@@ -53,6 +55,7 @@ export default {
     Vue.component('Tabs', Tabs)
     Vue.component('AppModal', AppModal)
     Vue.component('Footer', Footer)
+    Vue.component('FooterLinks', FooterLinks)
     Vue.component('Locale', Locale)
     Vue.component('NavDropdown', NavDropdown)
     Vue.component('NavItem', NavItem)

--- a/packages/vue-vocabulary/src/patterns/Footer/Footer.stories.js
+++ b/packages/vue-vocabulary/src/patterns/Footer/Footer.stories.js
@@ -1,0 +1,49 @@
+import Footer from './Footer'
+
+export default {
+  title: 'Patterns/Footer',
+  component: Footer
+}
+
+const demoLinks = [
+  {
+    href: '#',
+    content: 'Item 1'
+  },
+  {
+    href: '#',
+    content: 'Item 2'
+  },
+  {
+    href: '#',
+    content: 'Item 3'
+  },
+  {
+    href: '#',
+    content: 'Item 4'
+  },
+  {
+    href: '#',
+    content: 'Item 5'
+  },
+  {
+    href: '#',
+    content: 'Item 6'
+  },
+  {
+    href: '#',
+    content: 'Item 7'
+  }
+]
+
+const Template = '<Footer v-bind="$props"></Footer>'
+
+export const Default = () => ({
+  components: { Footer },
+  template: Template,
+  props: {
+    links: {
+      default: () => demoLinks
+    }
+  }
+})

--- a/packages/vue-vocabulary/src/patterns/Footer/Footer.vue
+++ b/packages/vue-vocabulary/src/patterns/Footer/Footer.vue
@@ -1,7 +1,93 @@
 <template>
-  <footer class="vocab footer">
-    <!-- TODO -->
-  </footer>
+<footer class="main-footer">
+  <div class="container">
+    <div class="columns">
+      <div class="column is-one-quarter">
+        <a href="https://creativecommons.org" aria-label="home" class="main-logo margin-bottom-bigger">
+          <span class="has-text-white">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 304 73">
+              <use href="@creativecommons/vocabulary/assets/logos/cc/logomark.svg#logomark"></use>
+            </svg>
+          </span>
+        </a>
+        <div>
+          <address class="margin-bottom-normal">Creative Commons<br/>PO Box 1866, Mountain View CA 94042</address>
+          <a href="mailto:info@creativecommons.org" class="mail">info@creativecommons.org</a><br/>
+          <a href="tel://+1-415-429-6753" class="phone">+1-415-429-6753</a>
+        </div>
+        <div class="margin-vertical-large">
+          <a href="https://www.instagram.com/creativecommons" aria-label="instagram" class="social has-text-white" target="_blank" rel="noopener">
+            <i class="icon margin-right-small is-size-4">instagram</i>
+          </a>
+          <a href="https://www.twitter.com/creativecommons" aria-label="twitter" class="social has-text-white" target="_blank" rel="noopener">
+            <i class="icon margin-right-small is-size-4">twitter</i>
+          </a>
+          <a href="https://www.facebook.com/creativecommons" aria-label="facebook" class="social has-text-white" target="_blank" rel="noopener">
+            <i class="icon margin-right-small is-size-4">facebook</i>
+          </a>
+          <a href="https://www.linkedin.com/company/creative-commons/" aria-label="linkedin" class="social has-text-white" target="_blank" rel="noopener">
+            <i class="icon margin-right-small is-size-4">linkedin</i>
+          </a>
+        </div>
+      </div>
+      <div class="column is-three-quarters">
+        <div class="columns">
+          <div class="column is-full">
+            <nav aria-label="footerlinks" class="footer-navigation">
+        <ul class="menu">
+            <li v-for="link in links" :key="link.content">
+                <FooterLink is="a" :target="link.target" :href="link.href" class="menu-item">{{link.content}}</FooterLink>
+            </li>
+        </ul>
+    </nav>
+          </div>
+        </div>
+        <div class="columns">
+          <div class="column is-two-thirds">
+            <slot>
+              <div class="subscription">
+                <h5 class="b-header">Subscribe to our newsletter</h5>
+                <form class="newsletter">
+                  <label for="email" class="is-sr-only">Email to subscribe</label>
+                  <input type="text" id="email" class="input" placeholder="Your email">
+                  <input type="submit" value="subscribe" class="button small">
+                </form>
+              </div>
+            </slot>
+            <div class="attribution margin-top-bigger">
+              <p class="caption">
+                Except where otherwise
+                <a href="https://creativecommons.org/policies#license" target="_blank" rel="noopener">noted</a>,
+                content on this site is licensed under a
+                <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener">Creative Commons Attribution 4.0 International license</a>.
+                <a href="https://creativecommons.org/website-icons" target="_blank" rel="noopener">Icons</a>
+                by
+                <a href="https://fontawesome.com/" target="_blank" rel="noopener">Font Awesome</a>.
+              </p>
+              <div class="margin-top-smaller">
+                <i class="icon margin-right-small is-size-4">cclogo</i>
+                <i class="icon margin-right-small is-size-4">ccby</i>
+              </div>
+            </div>
+          </div>
+          <div class="column is-one-third">
+            <aside class="donate-section">
+              <h5>Our work relies on you!</h5>
+              <p>Help us keep the internet free and open.</p>
+              <a class="button small donate" href="http://creativecommons.org/donate">
+                <i class="icon cc-letterheart-filled margin-right-small is-size-5 padding-top-smaller"></i>
+                Donate now
+              </a>
+            </aside>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</footer>
 </template>
 
 <script>
@@ -11,7 +97,38 @@
    * The footer displays information about the site such as its developers and
    * maintainers as well as licensing information.
    */
+  import FooterLink from './FooterLink'
   export default {
-    name: 'Footer'
+    name: 'Footer',
+    components: {
+      FooterLink
+    },
+    props: {
+      links: {
+        type: Array[Object],
+        required: false,
+        validator (value) {
+          return value.length <= 7
+        },
+        default: [
+          {
+            href: 'https://creativecommons.org/about/contact/',
+            content: 'Contact'
+          },
+          {
+            href: 'https://creativecommons.org/privacy/',
+            content: 'Privacy'
+          },
+          {
+            href: 'https://creativecommons.org/policies/',
+            content: 'Policies'
+          },
+          {
+            href: 'https://creativecommons.org/terms/',
+            content: 'Terms'
+          }
+        ]
+      }
+    }
   }
 </script>

--- a/packages/vue-vocabulary/src/patterns/Footer/FooterLink.vue
+++ b/packages/vue-vocabulary/src/patterns/Footer/FooterLink.vue
@@ -1,0 +1,38 @@
+<template>
+    <div v-if="is==a"><a :href=href :rel=rel :target=target>
+      {{ content }}
+      </a></div>
+      <div v-else><router-link :to=to>
+      {{ content }}</router-link></div>
+</template>
+<script>
+  export default {
+    name: 'FooterLink',
+    props: {
+      is: {
+        type: String,
+        required: false
+      },
+      href: {
+        type: String,
+        required: false
+      },
+      content: {
+        type: String,
+        required: false
+      },
+      rel: {
+        type: String,
+        required: false
+      },
+      target: {
+        type: String,
+        required: false
+      },
+      to: {
+        type: String,
+        required: false
+      }
+    }
+  }
+</script>


### PR DESCRIPTION
## Fixes
Fixes issue #689 

## Description
Adds the Footer component to vue-vocabulary and the vue-vocabulary storybook. Implemented a parent-child component structure for further flexibility for adding more links in the footer.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
