### PR TITLE
Fixed: Main logo page crashing

### DIFF
--- a/packages/vocabulary/src/stories/main_logos.stories.mdx
+++ b/packages/vocabulary/src/stories/main_logos.stories.mdx
@@ -20,9 +20,12 @@ ${svgCode(304, 73, 'cc/logomark', 'logomark')}
 
 <Preview mdxSource={whiteText(logomarkSvg)} style={{backgroundColor: 'black'}}>
   <Story name="Logomark Inverted" height="128px" parameters={{
-    backgrounds: [
-      { name: 'black', value: 'black', default: true }
-    ],
+    backgrounds: {
+      default: 'black',
+      values: [
+        { name: 'black', value: 'black' },
+      ],
+    },
     design: figmaConfig('476%3A0')
   }}>{
     whiteText(logomarkSvg)


### PR DESCRIPTION
## Fixes
Fixes #853  by @darkshredder

## Description
Currently when we navigate to main logo page of documentation the whole page crashes.As there is code does not follow as per current documentation.So I have changed the code as per current documentation

## Screenshots
![Screenshot from 2021-02-21 22-17-14](https://user-images.githubusercontent.com/52625656/108637431-9b176580-74b0-11eb-881a-4312940a09a0.png)


## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
