### PR TITLE
Fixed responsiveness of image in card section in postVideoLarge component

### DIFF
--- a/packages/vocabulary/src/styles/card.scss
+++ b/packages/vocabulary/src/styles/card.scss
@@ -3,13 +3,12 @@ $card-content-padding: $space-big;
 $card-header-shadow: none;
 
 @import "bulma/sass/components/card.sass";
-@import "./mediaQueries.scss";
 
 .card {
-    &.entry-post {
+    &.entry-post { 
         display: flex;
         flex-direction: row;
-        @include responsive(phone) {
+        @include mobile() {
             flex-direction: column;
         }
         border: 3px solid $color-light-gray;
@@ -59,7 +58,7 @@ $card-header-shadow: none;
             }
         }
         &.horizontal {
-            display: flex;
+           display: flex;
             .card-content {
                 flex:1;
                 padding: $space-bigger;

--- a/packages/vocabulary/src/styles/card.scss
+++ b/packages/vocabulary/src/styles/card.scss
@@ -5,12 +5,8 @@ $card-header-shadow: none;
 @import "bulma/sass/components/card.sass";
 
 .card {
-    &.entry-post { 
-        display: flex;
-        flex-direction: row;
-        @include mobile() {
-            flex-direction: column;
-        }
+    &.entry-post {
+        display: block;
         border: 3px solid $color-light-gray;
         &.no-border {
             border: none;
@@ -58,7 +54,10 @@ $card-header-shadow: none;
             }
         }
         &.horizontal {
-           display: flex;
+            @include tablet() {
+                display: flex;
+            }
+
             .card-content {
                 flex:1;
                 padding: $space-bigger;
@@ -98,9 +97,6 @@ $card-header-shadow: none;
                 }
             }
             &.large {
-                &>* {
-                    flex: 0 0 auto;
-                }
                 .card-image {
                     a {
                         .image {
@@ -262,11 +258,11 @@ $card-header-shadow: none;
 
                         font-family: $family-heading;
                         font-weight: bold;
-                        
+
                         text-transform: uppercase;
                         line-height: 1.3;
                         letter-spacing: 0.02rem;
-                        
+
                         column-width: 33%;
                         display: block;
                         padding-bottom: $space-normal;

--- a/packages/vocabulary/src/styles/card.scss
+++ b/packages/vocabulary/src/styles/card.scss
@@ -3,9 +3,15 @@ $card-content-padding: $space-big;
 $card-header-shadow: none;
 
 @import "bulma/sass/components/card.sass";
+@import "./mediaQueries.scss";
 
 .card {
     &.entry-post {
+        display: flex;
+        flex-direction: row;
+        @include responsive(phone) {
+            flex-direction: column;
+        }
         border: 3px solid $color-light-gray;
         &.no-border {
             border: none;
@@ -55,9 +61,11 @@ $card-header-shadow: none;
         &.horizontal {
             display: flex;
             .card-content {
+                flex:1;
                 padding: $space-bigger;
             }
             .card-image {
+                flex:2;
                 .image {
                     height: 100%;
                     img {
@@ -95,7 +103,6 @@ $card-header-shadow: none;
                     flex: 0 0 auto;
                 }
                 .card-image {
-                    width: 70%;
                     a {
                         .image {
                             &:before {
@@ -110,7 +117,6 @@ $card-header-shadow: none;
                     }
                 }
                 .card-content {
-                    width: 30%;
                     .card-title {
                         text-transform: uppercase;
                         line-height: 3.7rem;

--- a/packages/vocabulary/src/styles/mediaQueries.scss
+++ b/packages/vocabulary/src/styles/mediaQueries.scss
@@ -1,0 +1,14 @@
+@mixin responsive($breakpoint) {
+    @if $breakpoint == phone {
+        @media only screen and (max-width: 600px) { @content };
+    }
+    @if $breakpoint == tab-port {
+        @media only screen and (max-width: 900px) { @content };
+    }
+    @if $breakpoint == tab-land {
+        @media only screen and (max-width: 1400px) { @content };
+    }
+    @if $breakpoint == big-desktop {
+        @media only screen and (min-width: 1800px) { @content };
+    }
+}


### PR DESCRIPTION


## Fixes #834 by @neeraj-2 

## Description
Image and card content in the cards section in postVideoLarge component were not responsive --used grid and media-query to fix the issue.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.


## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
