### PR TITLE
#issue 856, changed component Preview to Canvas

### DIFF
--- a/packages/fonts/.storybook/meta/welcome.stories.mdx
+++ b/packages/fonts/.storybook/meta/welcome.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 
 <Meta title="Fonts/Introduction" />
 
@@ -26,4 +26,3 @@ import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
 <a style={{ position: 'absolute', bottom: '0.5em', left: '0.5em' }} href="https://www.netlify.com" target="_blank">
   <img src="https://www.netlify.com/img/global/badges/netlify-light.svg"/>
 </a>
-

--- a/packages/vocabulary/.storybook/meta/welcome.stories.mdx
+++ b/packages/vocabulary/.storybook/meta/welcome.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 
 <Meta title="Vocabulary/Introduction" />
 

--- a/packages/vocabulary/src/stories/breadcrumb.stories.mdx
+++ b/packages/vocabulary/src/stories/breadcrumb.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Navigation/Breadcrumb" />
@@ -20,10 +20,10 @@ The Breadcrumb has two text styles: links to parent pages and the page the user 
 
 For accessibility purposes, the component should be placed above the page's title.
 
-<Preview mdxSource={breadCrumb()}>
+<Canvas mdxSource={breadCrumb()}>
   <Story name="Default" parameters={{
     design: figmaConfig('6368%3A9')
   }}>{
     breadCrumb()
   }</Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/buttons.stories.mdx
+++ b/packages/vocabulary/src/stories/buttons.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Elements/Buttons" />
@@ -43,25 +43,25 @@ export const buttonDonateClass = (classes, el = 'button', href='', label='Donate
 To create buttons, add the `.button` class to a `<button>` or an `<a>` element.
 By default, buttons are of `normal` size and `primary` theme.
 
-<Preview mdxSource={buttonSources([''])}>
+<Canvas mdxSource={buttonSources([''])}>
   <Story name="Button" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}>{
     defaultButton('normal')
   }</Story>
-</Preview>
+</Canvas>
 
 export const sizes = ['big', 'medium', 'normal','small', 'tiny']
 
 You can customize the size of buttons with the `.big`, `.medium`, `.normal`, `.small` and `.tiny` classes.
 
-<Preview mdxSource={buttonSources(sizes, true)}>
+<Canvas mdxSource={buttonSources(sizes, true)}>
   <Story name="Button Sizes" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}>
     {buttonSources(sizes, true)}
   </Story>
-</Preview>
+</Canvas>
 
 You can also combine other classes such as `.donate` with the aforementioned size classes.
 
@@ -70,60 +70,60 @@ export const donateButtonSizes = () => {
     .map((classes) => (buttonDonateClass(classes))).join('\n')
 }
 
-<Preview mdxSource={donateButtonSizes()}>
+<Canvas mdxSource={donateButtonSizes()}>
   <Story name="Button Donate Sizes" height="100px" parameters={{
     design: figmaConfig('1404%3A19')
   }}>
     {donateButtonSizes()}
   </Story>
-</Preview>
+</Canvas>
 
 In the header, the Donate button has a different design:
 
-<Preview mdxSource={buttonDonateClass()}>
+<Canvas mdxSource={buttonDonateClass()}>
   <Story name="Button Donate Header" height="100px" parameters={{
     design: figmaConfig('1404%3A19')
   }}>
     {buttonDonateClass('is-header', 'a', '', 'Donate')}
   </Story>
-</Preview>
+</Canvas>
 
 Buttons may have four feedback colors such as `.is-success`, `.is-info`, and `is-border`.
 
 export const feedbackClasses = ['is-success', 'is-info', 'is-border']
 
-<Preview mdxSource={buttonSources(feedbackClasses, {isDefaultLabel: true})}>
+<Canvas mdxSource={buttonSources(feedbackClasses, {isDefaultLabel: true})}>
   <Story name="Button Feedback Types" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}>{
     buttonSources(feedbackClasses, {isDefaultLabel: true})
   }</Story>
-</Preview>
+</Canvas>
 
 Buttons can be disabled:
 
 export const getFeedbackLabel = (className) => (className.replace('is-', ''))
 
-<Preview mdxSource={buttonSources(['', ...feedbackClasses, 'is-text'], {getLabel: getFeedbackLabel, disabled: true})}>
+<Canvas mdxSource={buttonSources(['', ...feedbackClasses, 'is-text'], {getLabel: getFeedbackLabel, disabled: true})}>
   <Story name="Button Disabled" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}>{
     buttonSources(['is-primary', ...feedbackClasses, 'is-text'], {getLabel: getFeedbackLabel, disabled: true})
   }</Story>
-</Preview>
+</Canvas>
 
 
 The `.tag` class is used to render a tag name.
 
-<Preview mdxSource={defaultButton('tag')}>
+<Canvas mdxSource={defaultButton('tag')}>
   <Story name="Tag" height="100px" parameters={{
     design: figmaConfig('1404%3A1')
   }}>{
     defaultButton('tag')
   }</Story>
-</Preview>
+</Canvas>
 
-<Preview>
+<Canvas>
   <Story name="Removable Tag" height="100px" parameters={{
     design: figmaConfig('1404%3A1')
   }}>{`
@@ -132,24 +132,24 @@ The `.tag` class is used to render a tag name.
       <i class="icon cross"></i>
     </button>
   `}</Story>
-</Preview>
+</Canvas>
 
 You can use the `.is-text` to have a button looking more like a link, with no borders and background color.
 
-<Preview mdxSource={defaultButton('is-text')}>
+<Canvas mdxSource={defaultButton('is-text')}>
   <Story name="Text Button" height="100px" parameters={{
     design: figmaConfig('1404%3A1')
   }}>{
     defaultButton('is-text')
   }</Story>
-</Preview>
+</canvas>
 
 Button styles should be applied to anchor tags (`<a>`) when using links. Avoid using JavaScript and `<button>` tags to replicate anchor tag behavior whenever possible.
 
-<Preview mdxSource={defaultButton('small', {el: 'a', href: 'https://creativecommons.org'})}>
+<Canvas mdxSource={defaultButton('small', {el: 'a', href: 'https://creativecommons.org'})}>
   <Story name="Anchor Tags" height="100px" parameters={{
     design: figmaConfig('1403%3A61')
   }}>{
     defaultButton('',  {el: 'a', href: 'https://creativecommons.org'})
   }</Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/buttons.stories.mdx
+++ b/packages/vocabulary/src/stories/buttons.stories.mdx
@@ -142,7 +142,7 @@ You can use the `.is-text` to have a button looking more like a link, with no bo
   }}>{
     defaultButton('is-text')
   }</Story>
-</canvas>
+</Canvas>
 
 Button styles should be applied to anchor tags (`<a>`) when using links. Avoid using JavaScript and `<button>` tags to replicate anchor tag behavior whenever possible.
 

--- a/packages/vocabulary/src/stories/cards.stories.mdx
+++ b/packages/vocabulary/src/stories/cards.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Layouts/Cards" />
@@ -25,7 +25,7 @@ export const cardWithButton = (width, image_size, orientation) => `<div style="w
   </article>
 </div>`
 
-<Preview mdxSource = {cardWithButton(400,'4by3', 'vertical')}>
+<Canvas mdxSource = {cardWithButton(400,'4by3', 'vertical')}>
   <Story name="PostVertical" parameters={{
     design: figmaConfig('776%3A0')
   }}>{`
@@ -33,9 +33,9 @@ export const cardWithButton = (width, image_size, orientation) => `<div style="w
       ${cardWithButton(400,'4by3', 'vertical')}
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview mdxSource = {cardWithButton(600,'4by5', 'horizontal')}>
+<Canvas mdxSource = {cardWithButton(600,'4by5', 'horizontal')}>
   <Story name="PostHorizontal" parameters={{
     design: figmaConfig('776%3A3')
   }}>{`
@@ -43,7 +43,7 @@ export const cardWithButton = (width, image_size, orientation) => `<div style="w
     ${cardWithButton(600,'4by5', 'horizontal')}
   </div>
   `}</Story>
-</Preview>
+</Canvas>
 
 export const postVideo = (width,image_size,orientation) => `<div style="width: ${width}px;">
       <article class="card entry-post entry-video ${orientation} no-border">
@@ -61,7 +61,7 @@ export const postVideo = (width,image_size,orientation) => `<div style="width: $
       </article>
     </div>`
 
-<Preview mdxSource = {postVideo(400,'4by3','vertical')}>
+<Canvas mdxSource = {postVideo(400,'4by3','vertical')}>
   <Story name="PostVideoVertical" parameters={{
     design: figmaConfig('776%3A86')
   }}>{`
@@ -69,9 +69,9 @@ export const postVideo = (width,image_size,orientation) => `<div style="width: $
     ${postVideo(400,'4by3','vertical')}
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview mdxSource = {postVideo(600,'','horizontal')}>
+<Canvas mdxSource = {postVideo(600,'','horizontal')}>
   <Story name="PostVideoHorizontal" parameters={{
     design: figmaConfig('776%3A86')
   }}>{`
@@ -79,9 +79,9 @@ export const postVideo = (width,image_size,orientation) => `<div style="width: $
     ${postVideo(600,'', 'horizontal')}
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview>
+<Canvas>
   <Story name="PostVideoLarge" parameters={{
     design: figmaConfig('776%3A86')
   }}>{`
@@ -103,7 +103,7 @@ export const postVideo = (width,image_size,orientation) => `<div style="width: $
       </article>
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
 
 export const postEvent = (width) => `<div
@@ -124,7 +124,7 @@ style="width: ${width}px;">
       </article>
     </div>`
 
-<Preview mdxSource = {postEvent(600)}>
+<Canvas mdxSource = {postEvent(600)}>
   <Story name="PostEventWide" parameters={{
     design: figmaConfig('776%3A43')
   }}>{`
@@ -132,9 +132,9 @@ style="width: ${width}px;">
     ${postEvent(600)}
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview mdxSource = {postEvent(350)}>
+<Canvas mdxSource = {postEvent(350)}>
   <Story name="PostEventNarrow" parameters={{
     design: figmaConfig('776%3A43')
   }}>{`
@@ -142,9 +142,9 @@ style="width: ${width}px;">
     ${postEvent(350)}
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview>
+<Canvas>
   <Story name="PostStatistic" parameters={{
     design: figmaConfig('776%3A144')
   }}>{`
@@ -165,9 +165,9 @@ style="width: ${width}px;">
       </article>
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview>
+<Canvas>
   <Story name="PostQuote" parameters={{
     design: figmaConfig('776%3A3')
   }}>{`
@@ -191,9 +191,9 @@ style="width: ${width}px;">
       </article>
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview>
+<Canvas>
   <Story name="ImageTop" parameters={{
     design: figmaConfig('776%3A3')
   }}> {`
@@ -213,7 +213,7 @@ style="width: ${width}px;">
       </article>
     </div>`
   }</Story>
-</Preview>
+</Canvas>
 
 export const linkCard = `<article class="card entry-post link no-border">
   <a href="#" class="has-background-dark-slate-blue">
@@ -225,7 +225,7 @@ export const linkCard = `<article class="card entry-post link no-border">
   </a>
 </article>`
 
-<Preview mdxSource = {linkCard}>
+<Canvas mdxSource = {linkCard}>
   <Story name="Link" parameters={{
     design: figmaConfig('776%3A122')
   }}>{`
@@ -233,7 +233,7 @@ export const linkCard = `<article class="card entry-post link no-border">
       ${linkCard.toString()}
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
 
 export const linkBorderCard = `<article class="card entry-post link">
@@ -245,7 +245,7 @@ export const linkBorderCard = `<article class="card entry-post link">
   </a>
 </article>`
 
-<Preview mdxSource = {linkBorderCard}>
+<Canvas mdxSource = {linkBorderCard}>
   <Story name="Link Border" parameters={{
     design: figmaConfig('776%3A122')
   }}>{`
@@ -253,10 +253,10 @@ export const linkBorderCard = `<article class="card entry-post link">
       ${linkBorderCard.toString()}
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
 
-<Preview>
+<Canvas>
   <Story name="Blog entry horizontal" parameters={{
     design: figmaConfig('776%3A3')
   }}>{`
@@ -277,9 +277,9 @@ export const linkBorderCard = `<article class="card entry-post link">
       </article>
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview>
+<Canvas>
   <Story name="Project index" parameters={{
     design: figmaConfig('776%3A144')
   }}>{`
@@ -318,4 +318,4 @@ export const linkBorderCard = `<article class="card entry-post link">
       </article>
     </div>
   `}</Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/checkbox.stories.mdx
+++ b/packages/vocabulary/src/stories/checkbox.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Form/Checkbox" />
@@ -32,11 +32,11 @@ export const checkboxDiv = () => `<h3>Checkbox</h3>
   </label>
 </div>`
 
-<Preview mdxSource={checkboxDiv()}>
+<Canvas mdxSource={checkboxDiv()}>
   <Story name="Default" height="200px" parameters={{
     design: figmaConfig('603%3A3')
   }}>{
     checkboxDiv()
   }</Story>
-</Preview>
+</Canvas>
 

--- a/packages/vocabulary/src/stories/color.stories.mdx
+++ b/packages/vocabulary/src/stories/color.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview, ColorPalette, ColorItem } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas, ColorPalette, ColorItem } from "@storybook/addon-docs/blocks";
 import { figmaConfig } from "./helpers";
 
 <Meta title="Tokens/Color" />
@@ -129,11 +129,11 @@ export const helperExamples = () => `
   on a light grey background
 </div>`;
 
-<Preview mdxSource={helperExamples()}>
+<Canvas mdxSource={helperExamples()}>
   <Story name="Helpers" height="250px">
     {helperExamples}
   </Story>
-</Preview>
+</Canvas>
 
 <Story
   name="Figma"

--- a/packages/vocabulary/src/stories/combined_header.stories.mdx
+++ b/packages/vocabulary/src/stories/combined_header.stories.mdx
@@ -1,5 +1,5 @@
 import { useEffect } from '@storybook/client-api'
-import { Meta, Preview, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks'
 import { createGlobalHeader } from '../scripts/global_header'
 import { header } from './helpers'
 
@@ -13,7 +13,7 @@ import { header } from './helpers'
 
 export const globalHeader = 'const globalHeaderInstance = vocabulary.createGlobalHeader()'
 
-<Preview mdxSource={globalHeader} className="tight">
+<Canvas mdxSource={globalHeader} className="tight">
   <Story name="Interactive">{() => {
     // Using Storybook hooks to clean up effects of DOM insertion
     useEffect(() => {
@@ -28,4 +28,4 @@ export const globalHeader = 'const globalHeaderInstance = vocabulary.createGloba
     })
     return header('rgb(237, 89, 47)')
   }}</Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/footer.stories.mdx
+++ b/packages/vocabulary/src/stories/footer.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks'
 import { figmaConfig, svgCode } from './helpers'
 
 <Meta title="Patterns/Footer" />
@@ -93,10 +93,10 @@ export const footer = () => `
   </div>
 </footer>`
 
-<Preview mdxSource={footer()}>
+<Canvas mdxSource={footer()}>
   <Story name="Default" parameters={{
     design: figmaConfig("639%3A185")
   }}>{
     footer()
   }</Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/github_corner.stories.mdx
+++ b/packages/vocabulary/src/stories/github_corner.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Elements/GitHub corner" />
@@ -17,13 +17,13 @@ export const isNormal = `<a class="github-corner">
   ${GitHubCorner}
 </a>`
 
-<Preview mdxSource={isNormal} className="tight">
+<Canvas mdxSource={isNormal} className="tight">
   <Story name="Normal" height="120px" parameters={{
     design: figmaConfig('795%3A1')
   }}>{
     isNormal.toString()
   }</Story>
-</Preview>
+</Canvas>
 
 This is the classic black ribbon. Most pages use the GitHub corner in this fashion.
 
@@ -31,14 +31,14 @@ export const isInverted = `<a class="github-corner is-inverted">
   ${GitHubCorner}
 </a>`
 
-<Preview mdxSource={isInverted} style={{backgroundColor: 'black'}} className="tight">
+<Canvas mdxSource={isInverted} style={{backgroundColor: 'black'}} className="tight">
   <Story name="Inverted" height="120px" parameters={{
     backgrounds: { default: 'black' },
     design: figmaConfig('795%3A1')
   }}>{
     isInverted.toString()
   }</Story>
-</Preview>
+</Canvas>
 
 The colors may be inverted when displaying on darker, non-white backgrounds.
 
@@ -46,13 +46,13 @@ export const isLeftAligned = `<a class="github-corner is-left-aligned">
   ${GitHubCorner}
 </a>`
 
-<Preview mdxSource={isLeftAligned} className="tight">
+<Canvas mdxSource={isLeftAligned} className="tight">
   <Story name="Left aligned" height="120px" parameters={{
     design: figmaConfig('795%3A1')
   }}>{
     isLeftAligned.toString()
   }</Story>
-</Preview>
+</Canvas>
 
 If the right side of the page is too bloated, or if the language is read and written RTL, the position of the ribbon may
 be flipped over to the left hand side.

--- a/packages/vocabulary/src/stories/global_header.stories.mdx
+++ b/packages/vocabulary/src/stories/global_header.stories.mdx
@@ -1,5 +1,5 @@
 import { useEffect } from '@storybook/client-api'
-import { Meta, Preview, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks'
 import { createGlobalHeader } from '../scripts/global_header'
 
 <Meta
@@ -12,7 +12,7 @@ import { createGlobalHeader } from '../scripts/global_header'
 
 export const globalHeader = 'const globalHeaderInstance = vocabulary.createGlobalHeader()'
 
-<Preview mdxSource={globalHeader} className="tight">
+<Canvas mdxSource={globalHeader} className="tight">
   <Story name="Interactive">{() => {
     // Using Storybook hooks to clean up effects of DOM insertion
     useEffect(() => {
@@ -27,4 +27,4 @@ export const globalHeader = 'const globalHeaderInstance = vocabulary.createGloba
     })
     return '<div style="background-color: rgb(237, 89, 47); height: 200px;"></div>'
   }}</Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/grid.stories.mdx
+++ b/packages/vocabulary/src/stories/grid.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Layouts/Grid" />
@@ -18,7 +18,7 @@ export const cols = (number, color) => {
 
 ## Fullhd
 
-<Preview mdxSource = {`
+<Canvas mdxSource = {`
 <div style="width: 1248px;">
   <div class="container columns">
     ${cols(1,'tomato')}
@@ -48,11 +48,11 @@ export const cols = (number, color) => {
   </div>
   </div>
   `}</Story>
-</Preview>
+</Canvas>
 
 ## Desktop
 
-<Preview mdxSource = {`
+<Canvas mdxSource = {`
 <div style="width: 952px;">
   <div class="container columns">
     ${cols(1,'tomato')}
@@ -82,11 +82,11 @@ export const cols = (number, color) => {
   </div>
   </div>
   `}</Story>
-</Preview>
+</Canvas>
 
 ## Tablet
 
-<Preview mdxSource = {`
+<Canvas mdxSource = {`
 <div style="width: 736px;">
   <div class="columns">
     ${cols(1,'tomato')}
@@ -116,11 +116,11 @@ export const cols = (number, color) => {
   </div>
   </div>
   `}</Story>
-</Preview>
+</Canvas>
 
 ## Mobile
 
-<Preview mdxSource = {`
+<Canvas mdxSource = {`
 <div style="width: 276px;">
   <div class="columns">
     ${cols(1,'tomato')}
@@ -150,7 +150,7 @@ export const cols = (number, color) => {
   </div>
   </div>
   `}</Story>
-</Preview>
+</Canvas>
 
 [Bulma](https://bulma.io) also offers further customisation with respect to the column widths. If you prefer, bulma column width classes such as `is-three-quarters` can also be explicitly applied to any individual column. This would then force the column to occupy three-fourths of the total container width, which by default spaces out equally. Bulma also offers provisions to modify the size, responsiveness, nesting, gap and other customised variants.
 

--- a/packages/vocabulary/src/stories/header.stories.mdx
+++ b/packages/vocabulary/src/stories/header.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks'
 import { header } from './helpers'
 
 <Meta title="Patterns/Header" />
@@ -33,10 +33,10 @@ export const compactHeader = (color) => `<div style="width:640px">
       <div style="background-color: ${color}; height: 200px;"></div>
     </div>`
 
-<Preview mdxSource={header('rgb(237, 89, 47)')}>
+<Canvas mdxSource={header('rgb(237, 89, 47)')}>
   <Story name="Default" height="350px">{header('rgb(237, 89, 47)')}</Story>
-</Preview>
+</Canvas>
 
-<Preview mdxSource={compactHeader('rgb(5, 181, 218)')}>
+<Canvas mdxSource={compactHeader('rgb(5, 181, 218)')}>
   <Story name="Compact" height="320px">{compactHeader('rgb(5, 181, 218)')}</Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/image.stories.mdx
+++ b/packages/vocabulary/src/stories/image.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Patterns/Image" />
@@ -9,7 +9,7 @@ The image component is not restricted to a specific size; it must be used
 depending on the content type and its container. If it is placed as a single
 image within the content, it should follow the grid columns.
 
-<Preview>
+<Canvas>
   <Story name="Default" height="300px" parameters={{
     design: figmaConfig('576%3A1')}}>{`
     <div class="image" style="max-width: 384px;">
@@ -24,9 +24,9 @@ image within the content, it should follow the grid columns.
       </div>
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview>
+<Canvas>
   <Story name="Long title" height="300px" parameters={{
     design: figmaConfig('576%3A1')}}>{`
     <div class="image" style="max-width: 384px;">
@@ -41,9 +41,9 @@ image within the content, it should follow the grid columns.
       </div>
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview>
+<Canvas>
   <Story name="Ellipsised" height="300px" parameters={{
     design: figmaConfig('576%3A1')}}>{`
     <div class="image" style="max-width: 384px;">
@@ -58,9 +58,9 @@ image within the content, it should follow the grid columns.
       </div>
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview>
+<Canvas>
   <Story name="Compact" height="500px" parameters={{
     design: figmaConfig('576%3A1')}}>{`
     <div class="image is-compact" style="max-width: 384px;">
@@ -78,9 +78,9 @@ image within the content, it should follow the grid columns.
       </div>
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview>
+<Canvas>
   <Story name="Selected" height="500px" parameters={{
     design: figmaConfig('576%3A1')}}>{`
     <div class="image is-selected" style="max-width: 384px;">
@@ -95,7 +95,7 @@ image within the content, it should follow the grid columns.
       </div>
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
 
 [Broadway Tower](https://commons.wikimedia.org/wiki/File:Broadway_tower.jpg)

--- a/packages/vocabulary/src/stories/input.stories.mdx
+++ b/packages/vocabulary/src/stories/input.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Form/Input" />
@@ -182,82 +182,82 @@ export const inputsWithIcons = () => `
 `
 
 
-<Preview mdxSource={inputType('')}>
+<Canvas mdxSource={inputType('')}>
   <Story name="Normal" height="200px" parameters={{
     design: figmaConfig('1%3A24')
   }}>{
     inputType('')
   }</Story>
-</Preview>
+</Canvas>
 
-<Preview mdxSource={inputType('medium')}>
+<Canvas mdxSource={inputType('medium')}>
   <Story name="Medium" height="250px" parameters={{
     design: figmaConfig('1%3A24')
   }}>{
     inputType('medium')
   }</Story>
-</Preview>
+</Canvas>
 
-<Preview mdxSource={inputType('large')}>
+<Canvas mdxSource={inputType('large')}>
   <Story name="Large" height="320px" parameters={{
     design: figmaConfig('1%3A24')
   }}>{
     inputType('large')
   }</Story>
-</Preview>
+</Canvas>
 
-<Preview mdxSource={inputTypeLabel('')}>
+<Canvas mdxSource={inputTypeLabel('')}>
   <Story name="Normal (+ label)" height="200px" parameters={{
     design: figmaConfig('1%3A24')
   }}>{
     inputTypeLabel('')
   }</Story>
-</Preview>
+</Canvas>
 
-<Preview mdxSource={inputTypeLabelMed('medium')}>
+<Canvas mdxSource={inputTypeLabelMed('medium')}>
   <Story name="Medium (+ label)" height="250px" parameters={{
     design: figmaConfig('1%3A24')
   }}>{
     inputTypeLabelMed('medium')
   }</Story>
-</Preview>
+</Canvas>
 
-<Preview mdxSource={inputTypeLabelLarge('large')}>
+<Canvas mdxSource={inputTypeLabelLarge('large')}>
   <Story name="Large (+ label)" height="320px" parameters={{
     design: figmaConfig('1%3A24')
   }}>{
     inputTypeLabelLarge('large')
   }</Story>
-</Preview>
+</Canvas>
 
-<Preview mdxSource={inputTypeNameDesc('')}>
+<Canvas mdxSource={inputTypeNameDesc('')}>
   <Story name="Normal (+ name, description)" height="200px" parameters={{
     design: figmaConfig('1%3A24')
   }}>{
     inputTypeNameDesc('')
   }</Story>
-</Preview>
+</Canvas>
 
-<Preview mdxSource={inputTypeNameDescMed('medium')}>
+<Canvas mdxSource={inputTypeNameDescMed('medium')}>
   <Story name="Medium (+ name, description)" height="250px" parameters={{
     design: figmaConfig('1%3A24')
   }}>{
     inputTypeNameDescMed('medium')
   }</Story>
-</Preview>
+</Canvas>
 
-<Preview mdxSource={inputTypeNameDescLarge('large')}>
+<Canvas mdxSource={inputTypeNameDescLarge('large')}>
   <Story name="Large (+ name, description)" height="320px" parameters={{
     design: figmaConfig('1%3A24')
   }}>{
     inputTypeNameDescLarge('large')
   }</Story>
-</Preview>
+</Canvas>
 
-<Preview mdxSource={inputsWithIcons()}>
+<Canvas mdxSource={inputsWithIcons()}>
   <Story name="With Icons" height="320px" parameters={{
     design: figmaConfig('1%3A24')
   }}>{
     inputsWithIcons()
   }</Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/license_badge.stories.mdx
+++ b/packages/vocabulary/src/stories/license_badge.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Assets/License badges" />
@@ -22,37 +22,37 @@ export const licenseSVG = (size, license) => {
 </svg>`
 }
 
-<Preview mdxSource={[licenseSVG('big', 'by'), licenseSVG('small', 'by')].join('\n\n')}>
+<Canvas mdxSource={[licenseSVG('big', 'by'), licenseSVG('small', 'by')].join('\n\n')}>
   <Story name="BY" height="96px" parameters={{
     design: figmaConfig("574%3A111")
   }}>{`
     <div>${licenseSVG('big', 'by')}</div>
     <div>${licenseSVG('small', 'by')}</div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview mdxSource={[licenseSVG('big', 'by_sa'), licenseSVG('small', 'by_sa')].join('\n\n')}>
+<Canvas mdxSource={[licenseSVG('big', 'by_sa'), licenseSVG('small', 'by_sa')].join('\n\n')}>
   <Story name="BY SA" height="96px" parameters={{
     design: figmaConfig("574%3A111")
   }}>{`
     <div>${licenseSVG('big', 'by_sa')}</div>
     <div>${licenseSVG('small', 'by_sa')}</div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview mdxSource={[licenseSVG('small', 'by_nd'), licenseSVG('big', 'by_nd')].join('\n\n')}>
+<Canvas mdxSource={[licenseSVG('small', 'by_nd'), licenseSVG('big', 'by_nd')].join('\n\n')}>
   <Story name="BY ND" height="96px" parameters={{
     design: figmaConfig("574%3A111")
   }}>{`
     <div>${licenseSVG('big', 'by_nd')}</div>
     <div>${licenseSVG('small', 'by_nd')}</div>
   `}</Story>
-</Preview>
+</Canvas>
 
 Big-sized licenses with the non-commercial clause include an EU variant with the Dollar symbol replaced with the Euro
 symbol. Small-sized licenses do not have this variant.
 
-<Preview mdxSource={[
+<Canvas mdxSource={[
     licenseSVG('big', 'by_nc'),
     licenseSVG('big', 'by_nc.eu'),
     licenseSVG('small', 'by_nc')
@@ -64,9 +64,9 @@ symbol. Small-sized licenses do not have this variant.
     <div>${licenseSVG('big', 'by_nc.eu')}</div>
     <div>${licenseSVG('small', 'by_nc')}</div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview mdxSource={[
+<Canvas mdxSource={[
     licenseSVG('big', 'by_nc_sa'),
     licenseSVG('big', 'by_nc_sa.eu'),
     licenseSVG('small', 'by_nc_sa')
@@ -78,9 +78,9 @@ symbol. Small-sized licenses do not have this variant.
     <div>${licenseSVG('big', 'by_nc_sa.eu')}</div>
     <div>${licenseSVG('small', 'by_nc_sa')}</div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview mdxSource={[
+<Canvas mdxSource={[
     licenseSVG('big', 'by_nc_nd'),
     licenseSVG('big', 'by_nc_nd.eu'),
     licenseSVG('small', 'by_nc_nd')
@@ -92,28 +92,28 @@ symbol. Small-sized licenses do not have this variant.
     <div>${licenseSVG('big', 'by_nc_nd.eu')}</div>
     <div>${licenseSVG('small', 'by_nc_nd')}</div>
   `}</Story>
-</Preview>
+</Canvas>
 
 Unlike other licenses that require attribution, CC Zero and Public Domain mark do not require the original creator to be
 attributed to in your work. They are the most permissive of these licenses.
 
-<Preview mdxSource={[licenseSVG('big', 'cc_zero'), licenseSVG('small', 'cc_zero')].join('\n\n')}>
+<Canvas mdxSource={[licenseSVG('big', 'cc_zero'), licenseSVG('small', 'cc_zero')].join('\n\n')}>
   <Story name="CC Zero" height="96px" parameters={{
     design: figmaConfig("574%3A111")
   }}>{`
     <div>${licenseSVG('big', 'cc_zero')}</div>
     <div>${licenseSVG('small', 'cc_zero')}</div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview mdxSource={[licenseSVG('big', 'publicdomain'), licenseSVG('small', 'publicdomain')].join('\n\n')}>
+<Canvas mdxSource={[licenseSVG('big', 'publicdomain'), licenseSVG('small', 'publicdomain')].join('\n\n')}>
   <Story name="Public Domain" height="96px" parameters={{
     design: figmaConfig("574%3A111")
   }}>{`
     <div>${licenseSVG('big', 'publicdomain')}</div>
     <div>${licenseSVG('small', 'publicdomain')}</div>
   `}</Story>
-</Preview>
+</Canvas>
 
 # Usage
 

--- a/packages/vocabulary/src/stories/locale.stories.mdx
+++ b/packages/vocabulary/src/stories/locale.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { figmaConfig } from "./helpers";
 
 <Meta title="Patterns/Locale" />
@@ -9,7 +9,7 @@ The locale component should be used to indicate and switch the language of the p
 displayed in the select component must show the current language and then the language’s name written in the language’s
 alphabet.
 
-<Preview>
+<Canvas>
   <Story name="Default" height="64px" parameters={{
     design: figmaConfig('753%3A0')
   }}>{`
@@ -32,4 +32,4 @@ alphabet.
       </div>
     </div>
   `}</Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/main_logos.stories.mdx
+++ b/packages/vocabulary/src/stories/main_logos.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 import { figmaConfig, svgCode, blackText, whiteText } from './helpers'
 
 <Meta title="Assets/Logos/Main" />
@@ -10,15 +10,15 @@ export const logomarkSvg = `
 ${svgCode(304, 73, 'cc/logomark', 'logomark')}
 `
 
-<Preview mdxSource={blackText(logomarkSvg)}>
+<Canvas mdxSource={blackText(logomarkSvg)}>
   <Story name="Logomark" height="128px" parameters={{
     design: figmaConfig('1%3A13')
   }}>{
     blackText(logomarkSvg)
   }</Story>
-</Preview>
+</Canvas>
 
-<Preview mdxSource={whiteText(logomarkSvg)} style={{backgroundColor: 'black'}}>
+<Canvas mdxSource={whiteText(logomarkSvg)} style={{backgroundColor: 'black'}}>
   <Story name="Logomark Inverted" height="128px" parameters={{
     backgrounds: [
       { name: 'black', value: 'black', default: true }
@@ -27,35 +27,35 @@ ${svgCode(304, 73, 'cc/logomark', 'logomark')}
   }}>{
     whiteText(logomarkSvg)
   }</Story>
-</Preview>
+</Canvas>
 
 export const lettermarkSvg = `
 <style>svg { height: 72px; }</style>
 ${svgCode(72, 72, 'cc/lettermark', 'lettermark')}
 `
 
-<Preview mdxSource={blackText(lettermarkSvg)}>
+<Canvas mdxSource={blackText(lettermarkSvg)}>
   <Story name="Lettermark" height="128px" parameters={{
     design: figmaConfig('712%3A8')
   }}>{`
     <p>${blackText(lettermarkSvg)}</p>
     <p class="caption"><strong>Note</strong>: Also available as an icon.</p>
   `}</Story>
-</Preview>
+</Canvas>
 
 export const letterheartSvg = `
 <style>svg { height: 72px; }</style>
 ${svgCode(80, 72, 'cc/letterheart', 'letterheart')}
 `
 
-<Preview mdxSource={blackText(letterheartSvg)}>
+<Canvas mdxSource={blackText(letterheartSvg)}>
   <Story name="Letterheart" height="128px" parameters={{
     design: figmaConfig('712%3A7')
   }}>{`
     <p>${blackText(letterheartSvg)}</p>
     <p class="caption"><strong>Note</strong>: Also available as an icon.</p>
   `}</Story>
-</Preview>
+</Canvas>
 
 The CC lettermark and the CC "letterheart" can also be found as icons for easier
 embedding in other components, like buttons.

--- a/packages/vocabulary/src/stories/modal.stories.mdx
+++ b/packages/vocabulary/src/stories/modal.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 
 <Meta title="Patterns/Modal" />
 
@@ -33,8 +33,8 @@ export const ModalContainer = () => {
 </div>`
 }
 
-<Preview mdxSource={ModalContainer()}>
+<Canvas mdxSource={ModalContainer()}>
   <Story name="Modal">{
     ModalContainer()
   }</Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/notification.stories.mdx
+++ b/packages/vocabulary/src/stories/notification.stories.mdx
@@ -1,9 +1,9 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Layouts/Notification" />
 
-<Preview>
+<Canvas>
   <Story name="Warning">{`
     <div class="notification warning">
       <a href="#" class="notification-container">
@@ -15,9 +15,9 @@ import { figmaConfig } from './helpers'
       </a>
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview>
+<Canvas>
   <Story name="Content">{`
     <div class="notification content">
       <a href="#" class="notification-container">
@@ -33,9 +33,9 @@ import { figmaConfig } from './helpers'
         </span>
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview>
+<Canvas>
   <Story name="Compact Notification">{`
     <div class="notification is-compact">
       <span class="notification-container has-background-success-light">
@@ -43,4 +43,4 @@ import { figmaConfig } from './helpers'
       </span>
     </div>
   `}</Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/pagination.stories.mdx
+++ b/packages/vocabulary/src/stories/pagination.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Navigation/Pagination" />
@@ -7,7 +7,7 @@ import { figmaConfig } from './helpers'
 
 The pagination component allows the user to move between pages and indicates the amount of pages depending on what the user is seeing. It has two basic component: active and hover, and inactive.
 
-<Preview>
+<Canvas>
   <Story name="White background" parameters={{
     design: figmaConfig('7005%3A35')
   }}>{`
@@ -50,9 +50,9 @@ The pagination component allows the user to move between pages and indicates the
       <span class="pagination-ellipsis">&hellip;</span>
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview>
+<Canvas>
   <Story name="Grey background" parameters={{
     design: figmaConfig('7005%3A35')
   }}>{`
@@ -89,4 +89,4 @@ The pagination component allows the user to move between pages and indicates the
       <span class="pagination-ellipsis">&hellip;</span>
     </div>
   `}</Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/product_logos.stories.mdx
+++ b/packages/vocabulary/src/stories/product_logos.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { figmaConfig, svgCode, blackText } from "./helpers";
 
 <Meta title="Assets/Logos/Product" />
@@ -8,7 +8,7 @@ import { figmaConfig, svgCode, blackText } from "./helpers";
 export const certificatesSvg = `<style>svg { height: 40px; }</style>
 ${svgCode(215, 40, "products/certificates", "certificates")}`;
 
-<Preview mdxSource={blackText(certificatesSvg)}>
+<Canvas mdxSource={blackText(certificatesSvg)}>
   <Story
     name="Certificate"
     height="128px"
@@ -18,12 +18,12 @@ ${svgCode(215, 40, "products/certificates", "certificates")}`;
   >
     {blackText(certificatesSvg)}
   </Story>
-</Preview>
+</Canvas>
 
 export const chooserSvg = `<style>svg { height: 40px; }</style>
 ${svgCode(169, 40, "products/chooser", "chooser")}`;
 
-<Preview mdxSource={blackText(chooserSvg)}>
+<Canvas mdxSource={blackText(chooserSvg)}>
   <Story
     name="Chooser"
     height="128px"
@@ -33,12 +33,12 @@ ${svgCode(169, 40, "products/chooser", "chooser")}`;
   >
     {blackText(chooserSvg)}
   </Story>
-</Preview>
+</Canvas>
 
 export const globalNetworkSvg = `<style>svg { height: 40px; }</style>
 ${svgCode(278, 40, "products/global_network", "globalnetwork")}`;
 
-<Preview mdxSource={blackText(globalNetworkSvg)}>
+<Canvas mdxSource={blackText(globalNetworkSvg)}>
   <Story
     name="Global Network"
     height="128px"
@@ -48,12 +48,12 @@ ${svgCode(278, 40, "products/global_network", "globalnetwork")}`;
   >
     {blackText(globalNetworkSvg)}
   </Story>
-</Preview>
+</Canvas>
 
 export const globalSummitSvg = `<style>svg { height: 40px; }</style>
 ${svgCode(265, 40, "products/global_summit", "globalsummit")}`;
 
-<Preview mdxSource={blackText(globalSummitSvg)}>
+<Canvas mdxSource={blackText(globalSummitSvg)}>
   <Story
     name="Global Summit"
     height="128px"
@@ -63,12 +63,12 @@ ${svgCode(265, 40, "products/global_summit", "globalsummit")}`;
   >
     {blackText(globalSummitSvg)}
   </Story>
-</Preview>
+</Canvas>
 
 export const legalDatabaseSvg = `<style>svg { height: 40px; }</style>
 ${svgCode(269, 40, "products/legal_database", "legaldatabase")}`;
 
-<Preview mdxSource={blackText(legalDatabaseSvg)}>
+<Canvas mdxSource={blackText(legalDatabaseSvg)}>
   <Story
     name="Legal Database"
     height="128px"
@@ -78,12 +78,12 @@ ${svgCode(269, 40, "products/legal_database", "legaldatabase")}`;
   >
     {blackText(legalDatabaseSvg)}
   </Story>
-</Preview>
+</Canvas>
 
 export const openSourceSvg = `<style>svg { height: 40px; }</style>
 ${svgCode(235, 40, "products/open_source", "opensource")}`;
 
-<Preview mdxSource={blackText(openSourceSvg)}>
+<Canvas mdxSource={blackText(openSourceSvg)}>
   <Story
     name="Open Source"
     height="128px"
@@ -93,12 +93,12 @@ ${svgCode(235, 40, "products/open_source", "opensource")}`;
   >
     {blackText(openSourceSvg)}
   </Story>
-</Preview>
+</Canvas>
 
 export const searchSvg = `<style>svg { height: 40px; }</style>
 ${svgCode(145, 40, "products/search", "search")}`;
 
-<Preview mdxSource={blackText(searchSvg)}>
+<Canvas mdxSource={blackText(searchSvg)}>
   <Story
     name="Search"
     height="128px"
@@ -108,12 +108,12 @@ ${svgCode(145, 40, "products/search", "search")}`;
   >
     {blackText(searchSvg)}
   </Story>
-</Preview>
+</Canvas>
 
 export const stateOfTheCommonsSvg = `<style>svg { height: 40px; }</style>
 ${svgCode(380, 40, "products/state_of_the_commons", "stateofthecommons")}`;
 
-<Preview mdxSource={blackText(stateOfTheCommonsSvg)}>
+<Canvas mdxSource={blackText(stateOfTheCommonsSvg)}>
   <Story
     name="State of the Commons"
     height="128px"
@@ -123,12 +123,12 @@ ${svgCode(380, 40, "products/state_of_the_commons", "stateofthecommons")}`;
   >
     {blackText(stateOfTheCommonsSvg)}
   </Story>
-</Preview>
+</Canvas>
 
 export const vocabularySvg = `<style>svg { height: 40px; }</style>
 ${svgCode(212, 40, "products/vocabulary", "vocabulary")}`;
 
-<Preview mdxSource={blackText(vocabularySvg)}>
+<Canvas mdxSource={blackText(vocabularySvg)}>
   <Story
     name="Vocabulary"
     height="96px"
@@ -138,4 +138,4 @@ ${svgCode(212, 40, "products/vocabulary", "vocabulary")}`;
   >
     {blackText(vocabularySvg)}
   </Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/profile_image.stories.mdx
+++ b/packages/vocabulary/src/stories/profile_image.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Patterns/Profile image" />
@@ -11,7 +11,7 @@ needed, however, a `60px` square is a minimum size available.
 
 You can use Bulma size helpers like `is-128x128` to set the image size.
 
-<Preview>
+<Canvas>
   <Story name="Default" parameters={{
     design: figmaConfig('6728%3A329')
   }}>{`
@@ -19,11 +19,11 @@ You can use Bulma size helpers like `is-128x128` to set the image size.
       <img class="profile" src="demo/lion_dafrique.jpg">
     </figure>
   `}</Story>
-</Preview>
+</Canvas>
 
 You can also use CSS properties `height` and `width` to size the image.
 
-<Preview>
+<Canvas>
   <Story name="Custom sizes" parameters={{
     design: figmaConfig('6728%3A329')
   }}>{`
@@ -37,7 +37,7 @@ You can also use CSS properties `height` and `width` to size the image.
       <img class="profile" src="demo/lion_dafrique.jpg">
     </figure>
   `}</Story>
-</Preview>
+</Canvas>
 
 [Lion d'Afrique](https://commons.wikimedia.org/wiki/File:Lion_d'Afrique.jpg)
 by

--- a/packages/vocabulary/src/stories/radio.stories.mdx
+++ b/packages/vocabulary/src/stories/radio.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Form/Radio" />
@@ -19,10 +19,10 @@ export const radioDiv = () => `<h3>Radio buttons</h3>
   </label>
 </div>`
 
-<Preview mdxSource={radioDiv()}>
+<Canvas mdxSource={radioDiv()}>
   <Story name="Default" height="200px" parameters={{
     design: figmaConfig('603%3A3')
   }}>{
     radioDiv()
   }</Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/select.stories.mdx
+++ b/packages/vocabulary/src/stories/select.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Form/Select" />
@@ -30,10 +30,10 @@ export const selectDiv = () => `
   </select>
 </div>`
 
-<Preview mdxSource={selectDiv()}>
+<Canvas mdxSource={selectDiv()}>
   <Story name="Default" height="200px" parameters={{
     design: figmaConfig('603%3A6')
   }}>{
     selectDiv()
   }</Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/sidebar_menu.stories.mdx
+++ b/packages/vocabulary/src/stories/sidebar_menu.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Navigation/Sidebar menu" />
@@ -13,7 +13,7 @@ all sibling and child pages.
 The component has two states, active and inactive. The hover state of inactive
 elements should have the same style of active state.
 
-<Preview>
+<Canvas>
   <Story name="Default" parameters={{
     design: figmaConfig('6990%3A11')
   }}>{`
@@ -51,4 +51,4 @@ elements should have the same style of active state.
       </aside>
     </div>
   `}</Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/spacing.stories.mdx
+++ b/packages/vocabulary/src/stories/spacing.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Tokens/Spacing" />
@@ -54,11 +54,11 @@ export const helperExamples = () => `
   Margin of 2.5rem on left side
 </div>`
 
-<Preview mdxSource={helperExamples()}>
+<Canvas mdxSource={helperExamples()}>
   <Story name="Helpers" height="250px">{
     helperExamples
   }</Story>
-</Preview>
+</Canvas>
 
 <Story name="Figma" parameters={{
   design: figmaConfig('0%3A190'),

--- a/packages/vocabulary/src/stories/table_of_contents.stories.mdx
+++ b/packages/vocabulary/src/stories/table_of_contents.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Navigation/Table of Contents" />
@@ -16,7 +16,7 @@ section.
 The component has two states, active and inactive. The hover state of inactive
 elements should have the same style of active state.
 
-<Preview>
+<Canvas>
   <Story name="Default" parameters={{
     design: figmaConfig('6990%3A82')
   }}>{`
@@ -49,4 +49,4 @@ elements should have the same style of active state.
       </aside>
     </div>
   `}</Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/table_of_progress.stories.mdx
+++ b/packages/vocabulary/src/stories/table_of_progress.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Story } from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Navigation/Table of Progress" />
@@ -13,7 +13,7 @@ section.
 The component has two states, active and inactive. The hover state of inactive
 elements should have the same style of active state.
 
-<Preview>
+<Canvas>
   <Story name="Default" parameters={{
     design: figmaConfig('6990%3A133')
   }}>{`
@@ -53,4 +53,4 @@ elements should have the same style of active state.
       </ul>
     </div>
   `}</Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/tables.stories.mdx
+++ b/packages/vocabulary/src/stories/tables.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Layouts/Table" />
@@ -7,7 +7,7 @@ import { figmaConfig } from './helpers'
 
 ## Basic Content Table
 
-<Preview>
+<Canvas>
   <Story name="Basic Content" parameters={{
     design: figmaConfig('904%3A0')
   }}>{`
@@ -48,11 +48,11 @@ import { figmaConfig } from './helpers'
       </table>
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
 ## Rich Content Table
 
-<Preview>
+<Canvas>
   <Story name="Rich Content" parameters={{
     design: figmaConfig('904%3A0')
   }}>{`
@@ -109,4 +109,4 @@ import { figmaConfig } from './helpers'
       </tr>
     </table>
   `}</Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/tabs.stories.mdx
+++ b/packages/vocabulary/src/stories/tabs.stories.mdx
@@ -1,11 +1,11 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Layouts/Tabs" />
 
 # Tabs
 
-<Preview>
+<Canvas>
   <Story name="Tab" height="200px" parameters={{
     design: figmaConfig('933%3A1')
   }}>{`
@@ -26,9 +26,9 @@ import { figmaConfig } from './helpers'
       </div>
     </div>
   `}</Story>
-</Preview>
+</Canvas>
 
-<Preview>
+<Canvas>
   <Story name="Box Tab" height="200px" parameters={{
     design: figmaConfig('933%3A1')
   }}>{`
@@ -49,4 +49,4 @@ import { figmaConfig } from './helpers'
       </div>
     </div>
   `}</Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/textarea.stories.mdx
+++ b/packages/vocabulary/src/stories/textarea.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Form/Textarea" />
@@ -13,10 +13,10 @@ export const textArea = () => `
 <textarea class="textarea" disabled>Fixed text</textarea>
 `
 
-<Preview mdxSource={textArea()}>
+<Canvas mdxSource={textArea()}>
   <Story name="Default" height="500px" parameters={{
     design: figmaConfig('6340%3A0')
   }}>{
     textArea()
   }</Story>
-</Preview>
+</Canvas>

--- a/packages/vocabulary/src/stories/typography.stories.mdx
+++ b/packages/vocabulary/src/stories/typography.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview, Typeset } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas, Typeset } from '@storybook/addon-docs/blocks'
 import { figmaConfig } from './helpers'
 
 <Meta title="Tokens/Typography" />
@@ -65,15 +65,15 @@ Headings of type B need the class `.b-header` to be applied to heading tags from
 
 Heading styles can also be applied to any elements, regardless of semantic meaning, with the `.title is-x` and `.subtitle .is-x` classes:
 
-<Preview mdxSource={title()}>
+<Canvas mdxSource={title()}>
   <Story name="Heading- Title" height="250px">{
     title()
   }</Story>
-</Preview>
+</Canvas>
 
-<Preview mdxSource={subtitle()}>
+<Canvas mdxSource={subtitle()}>
   <Story name="Heading- Subitle" height="100px">{subtitle()}</Story>
-</Preview>
+</Canvas>
 
 This is useful in situations where you need an `<h1>` tag that _looks like_ an `<h2>`, for example.
 

--- a/packages/vue-vocabulary/.storybook/meta/welcome.stories.mdx
+++ b/packages/vue-vocabulary/.storybook/meta/welcome.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 
 import vocabularySvg from '@creativecommons/vocabulary/assets/logos/products/vocabulary.svg'
 import gitHubCornerSvg from '@creativecommons/vocabulary/assets/github_corner.svg'


### PR DESCRIPTION
## Fixes 
Fixes #856 by @shukshi

## Description
This pull request changes all the component named "Preview" to "Canvas"

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [ ] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
