### PR TITLE
mobile card width issue fix

### DIFF
--- a/src/components/cards/cards.stories.mdx
+++ b/src/components/cards/cards.stories.mdx
@@ -9,7 +9,7 @@ export const content = `<div class="content">
             Description metus ligula pharetra litora class massa viverra, facilisis cum aenean hendrerit eget magnis convallis.
           </div>`
 
-export const cardWithButton = (width, image_size, orientation) => `<div style="width: ${width}px;">
+export const cardWithButton = (width, image_size, orientation) => `<div style="max-width: ${width}px;">
   <article class="card entry-post ${orientation}">
     <header class="card-image">
       <figure class="image is-${image_size}">
@@ -45,7 +45,7 @@ export const cardWithButton = (width, image_size, orientation) => `<div style="w
   `}</Story>
 </Canvas>
 
-export const postVideo = (width,image_size,orientation) => `<div style="width: ${width}px;">
+export const postVideo = (width,image_size,orientation) => `<div style="max-width: ${width}px;">
       <article class="card entry-post entry-video ${orientation} no-border">
         <header class="card-image">
           <a href="#">
@@ -107,7 +107,7 @@ export const postVideo = (width,image_size,orientation) => `<div style="width: $
 
 
 export const postEvent = (width) => `<div
-style="width: ${width}px;">
+style="max-width: ${width}px;">
       <article class="card entry-post entry-event horizontal">
         <header class="card-header">
           <div class="card-date">
@@ -148,7 +148,7 @@ style="width: ${width}px;">
   <Story name="PostStatistic" parameters={{
     design: figmaConfig('776%3A144')
   }}>{`
-    <div style="width: 600px;">
+    <div style="max-width: 600px;">
       <article class="card entry-post entry-statistic horizontal no-border">
         <header class="card-header">
           <div class="card-statistic">
@@ -171,7 +171,7 @@ style="width: ${width}px;">
   <Story name="PostQuote" parameters={{
     design: figmaConfig('776%3A3')
   }}>{`
-    <div style="width: 600px;">
+    <div style="max-width: 600px;">
       <article class="card entry-post entry-quote horizontal no-border">
         <header class="card-image">
           <figure class="image is-1by1">
@@ -197,7 +197,7 @@ style="width: ${width}px;">
   <Story name="ImageTop" parameters={{
     design: figmaConfig('776%3A3')
   }}> {`
-    <div style="width: 340px;">
+    <div style="max-width: 340px;">
       <article class="card entry-post entry-image vertical">
         <header class="card-image">
           <a href="#">
@@ -229,7 +229,7 @@ export const linkCard = `<article class="card entry-post link no-border">
   <Story name="Link" parameters={{
     design: figmaConfig('776%3A122')
   }}>{`
-    <div style="width: 400px;">
+    <div style="max-width: 400px;">
       ${linkCard.toString()}
     </div>
   `}</Story>
@@ -249,7 +249,7 @@ export const linkBorderCard = `<article class="card entry-post link">
   <Story name="Link Border" parameters={{
     design: figmaConfig('776%3A122')
   }}>{`
-    <div style="width: 400px;">
+    <div style="max-width: 400px;">
       ${linkBorderCard.toString()}
     </div>
   `}</Story>
@@ -260,7 +260,7 @@ export const linkBorderCard = `<article class="card entry-post link">
   <Story name="Blog entry horizontal" parameters={{
     design: figmaConfig('776%3A3')
   }}>{`
-    <div style="width: 384px;" class="margin-normal">
+    <div style="max-width: 384px;" class="margin-normal">
       <article class="card entry-post horizontal no-border blog-entry">
         <header>
           <figure class="image blog-image">


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes #860 #906  by @brylie 

## Description
<!-- Concisely describe what the pull request does. -->
On mobile view, the card is not responsive as a result of the fixed-width defined.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] I replaced the fixed width with a max-width


[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
